### PR TITLE
fix: truncate oversized MCP output

### DIFF
--- a/.changeset/red-dancers-worry.md
+++ b/.changeset/red-dancers-worry.md
@@ -1,0 +1,6 @@
+---
+'@spences10/pi-mcp': patch
+---
+
+Add MCP tool output truncation with temp file preservation for
+oversized server responses.

--- a/packages/pi-confirm-destructive/package.json
+++ b/packages/pi-confirm-destructive/package.json
@@ -34,7 +34,7 @@
 		"test:watch": "vitest"
 	},
 	"dependencies": {
-		"@mariozechner/pi-coding-agent": "^0.70.2"
+		"@mariozechner/pi-coding-agent": "^0.70.5"
 	},
 	"devDependencies": {
 		"@types/node": "^25.6.0",

--- a/packages/pi-lsp/package.json
+++ b/packages/pi-lsp/package.json
@@ -37,7 +37,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@mariozechner/pi-coding-agent": "^0.70.2",
+		"@mariozechner/pi-coding-agent": "^0.70.5",
 		"typebox": "^1.1.33"
 	},
 	"devDependencies": {

--- a/packages/pi-mcp/README.md
+++ b/packages/pi-mcp/README.md
@@ -71,6 +71,10 @@ Use `/mcp list` to inspect connection state and `/mcp enable` or
 - discovers tools via `tools/list`
 - registers each discovered MCP tool with Pi
 - forwards model tool calls to the MCP server
+- truncates oversized MCP tool text output to the first 50 KiB or
+  2,000 lines
+- saves truncated full output to a local `/tmp/my-pi-mcp-output-*.txt`
+  file so it can be inspected with `read` or `rg`
 - cleans up server processes on session shutdown
 
 ## Using from a custom harness

--- a/packages/pi-mcp/package.json
+++ b/packages/pi-mcp/package.json
@@ -37,7 +37,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@mariozechner/pi-coding-agent": "^0.70.2"
+		"@mariozechner/pi-coding-agent": "^0.70.5"
 	},
 	"devDependencies": {
 		"@types/node": "^25.6.0",

--- a/packages/pi-mcp/src/index.ts
+++ b/packages/pi-mcp/src/index.ts
@@ -6,6 +6,7 @@ import {
 } from '@mariozechner/pi-coding-agent';
 import { McpClient, type McpServerConfig } from './client.js';
 import { load_mcp_config } from './config.js';
+import { format_mcp_tool_result } from './result.js';
 
 interface ServerState {
 	config: McpServerConfig;
@@ -211,14 +212,13 @@ export default async function mcp(pi: ExtensionAPI) {
 									}>;
 								};
 
-								const text =
-									result?.content
-										?.map((c) => c.text || '')
-										.join('\n') || JSON.stringify(result);
+								const formatted = format_mcp_tool_result(result);
 
 								return {
-									content: [{ type: 'text' as const, text }],
-									details: {},
+									content: [
+										{ type: 'text' as const, text: formatted.text },
+									],
+									details: formatted.details,
 								};
 							},
 						}),

--- a/packages/pi-mcp/src/result.test.ts
+++ b/packages/pi-mcp/src/result.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import {
+	format_mcp_tool_result,
+	truncate_mcp_tool_output,
+} from './result.js';
+
+describe('truncate_mcp_tool_output', () => {
+	it('leaves small output unchanged', () => {
+		const result = truncate_mcp_tool_output('hello', {
+			max_bytes: 50,
+			max_lines: 5,
+		});
+
+		expect(result.text).toBe('hello');
+		expect(result.details).toMatchObject({
+			truncated: false,
+			bytes: 5,
+			lines: 1,
+		});
+	});
+
+	it('truncates oversized byte output and saves the full text', () => {
+		const output = `start\n${'x'.repeat(80)}\nneedle-at-end`;
+		const result = truncate_mcp_tool_output(output, {
+			max_bytes: 24,
+			max_lines: 20,
+			tmp_dir: tmpdir(),
+		});
+
+		expect(result.details.truncated).toBe(true);
+		expect(result.text).toContain('MCP output truncated');
+		expect(result.text).toContain('Full output saved to');
+		expect(result.text).not.toContain('needle-at-end');
+		expect(result.details.full_output_path).toBeTruthy();
+		expect(
+			readFileSync(result.details.full_output_path!, 'utf8'),
+		).toBe(output);
+
+		rmSync(result.details.full_output_path!);
+	});
+
+	it('truncates oversized line output', () => {
+		const output = ['one', 'two', 'three', 'four'].join('\n');
+		const result = truncate_mcp_tool_output(output, {
+			max_bytes: 1_000,
+			max_lines: 2,
+		});
+
+		expect(result.details).toMatchObject({
+			truncated: true,
+			lines: 4,
+			preview_lines: 2,
+		});
+		expect(
+			result.text.startsWith('one\ntwo\n\n[MCP output truncated:'),
+		).toBe(true);
+		expect(
+			readFileSync(result.details.full_output_path!, 'utf8'),
+		).toBe(output);
+
+		rmSync(result.details.full_output_path!);
+	});
+});
+
+describe('format_mcp_tool_result', () => {
+	it('formats and truncates MCP text content', () => {
+		const result = format_mcp_tool_result({
+			content: [{ type: 'text', text: 'a'.repeat(60_000) }],
+		});
+
+		expect(result.details.truncated).toBe(true);
+		expect(result.details.max_bytes).toBe(50 * 1024);
+		expect(result.text).toContain('MCP output truncated');
+		expect(result.details.full_output_path).toBeTruthy();
+
+		rmSync(result.details.full_output_path!);
+	});
+});

--- a/packages/pi-mcp/src/result.ts
+++ b/packages/pi-mcp/src/result.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from 'node:crypto';
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export const MCP_RESULT_MAX_BYTES = 50 * 1024;
+export const MCP_RESULT_MAX_LINES = 2_000;
+
+export interface McpResultTruncationDetails {
+	truncated: boolean;
+	bytes: number;
+	lines: number;
+	max_bytes: number;
+	max_lines: number;
+	preview_bytes?: number;
+	preview_lines?: number;
+	full_output_path?: string;
+}
+
+export function format_mcp_tool_result(result: unknown): {
+	text: string;
+	details: McpResultTruncationDetails;
+} {
+	return truncate_mcp_tool_output(stringify_mcp_tool_result(result));
+}
+
+export function stringify_mcp_tool_result(result: unknown): string {
+	if (
+		result &&
+		typeof result === 'object' &&
+		Array.isArray((result as { content?: unknown }).content)
+	) {
+		return (result as { content: Array<{ text?: unknown }> }).content
+			.map((content) =>
+				typeof content.text === 'string' ? content.text : '',
+			)
+			.join('\n');
+	}
+
+	const json = JSON.stringify(result);
+	return typeof json === 'string' ? json : String(result);
+}
+
+export function truncate_mcp_tool_output(
+	text: string,
+	options: {
+		max_bytes?: number;
+		max_lines?: number;
+		tmp_dir?: string;
+	} = {},
+): { text: string; details: McpResultTruncationDetails } {
+	const max_bytes = options.max_bytes ?? MCP_RESULT_MAX_BYTES;
+	const max_lines = options.max_lines ?? MCP_RESULT_MAX_LINES;
+	const bytes = Buffer.byteLength(text, 'utf8');
+	const lines = count_lines(text);
+
+	if (bytes <= max_bytes && lines <= max_lines) {
+		return {
+			text,
+			details: {
+				truncated: false,
+				bytes,
+				lines,
+				max_bytes,
+				max_lines,
+			},
+		};
+	}
+
+	const full_output_path = write_full_output(text, options.tmp_dir);
+	let preview = take_first_lines(text, max_lines);
+	preview = take_first_utf8_bytes(preview, max_bytes);
+
+	const preview_bytes = Buffer.byteLength(preview, 'utf8');
+	const preview_lines = count_lines(preview);
+	const notice = [
+		`[MCP output truncated: ${format_bytes(bytes)} across ${lines} lines; showing first ${format_bytes(preview_bytes)} / ${preview_lines} lines.]`,
+		`Full output saved to ${full_output_path}`,
+		'Use rg/read against that file to inspect the remainder.',
+	].join('\n');
+
+	return {
+		text: preview ? `${preview}\n\n${notice}` : notice,
+		details: {
+			truncated: true,
+			bytes,
+			lines,
+			max_bytes,
+			max_lines,
+			preview_bytes,
+			preview_lines,
+			full_output_path,
+		},
+	};
+}
+
+function count_lines(text: string): number {
+	if (text.length === 0) return 0;
+	return text.split('\n').length;
+}
+
+function take_first_lines(text: string, max_lines: number): string {
+	const lines = text.split('\n');
+	if (lines.length <= max_lines) return text;
+	return lines.slice(0, max_lines).join('\n');
+}
+
+function take_first_utf8_bytes(
+	text: string,
+	max_bytes: number,
+): string {
+	if (Buffer.byteLength(text, 'utf8') <= max_bytes) return text;
+
+	let bytes = 0;
+	let output = '';
+	for (const char of text) {
+		const char_bytes = Buffer.byteLength(char, 'utf8');
+		if (bytes + char_bytes > max_bytes) break;
+		bytes += char_bytes;
+		output += char;
+	}
+	return output;
+}
+
+function write_full_output(text: string, tmp_dir = tmpdir()): string {
+	const path = join(
+		tmp_dir,
+		`my-pi-mcp-output-${process.pid}-${Date.now()}-${randomUUID()}.txt`,
+	);
+	writeFileSync(path, text, { encoding: 'utf8', mode: 0o600 });
+	return path;
+}
+
+function format_bytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	return `${(bytes / 1024).toFixed(1)} KiB`;
+}

--- a/packages/pi-nopeek/package.json
+++ b/packages/pi-nopeek/package.json
@@ -38,7 +38,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@mariozechner/pi-coding-agent": "^0.70.2"
+		"@mariozechner/pi-coding-agent": "^0.70.5"
 	},
 	"devDependencies": {
 		"@types/node": "^25.6.0",

--- a/packages/pi-omnisearch/package.json
+++ b/packages/pi-omnisearch/package.json
@@ -36,7 +36,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@mariozechner/pi-coding-agent": "^0.70.2"
+		"@mariozechner/pi-coding-agent": "^0.70.5"
 	},
 	"devDependencies": {
 		"@types/node": "^25.6.0",

--- a/packages/pi-recall/package.json
+++ b/packages/pi-recall/package.json
@@ -38,7 +38,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@mariozechner/pi-coding-agent": "^0.70.2"
+		"@mariozechner/pi-coding-agent": "^0.70.5"
 	},
 	"devDependencies": {
 		"@types/node": "^25.6.0",

--- a/packages/pi-redact/package.json
+++ b/packages/pi-redact/package.json
@@ -37,8 +37,8 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@mariozechner/pi-ai": "^0.70.2",
-		"@mariozechner/pi-coding-agent": "^0.70.2"
+		"@mariozechner/pi-ai": "^0.70.5",
+		"@mariozechner/pi-coding-agent": "^0.70.5"
 	},
 	"devDependencies": {
 		"@types/node": "^25.6.0",

--- a/packages/pi-skills/package.json
+++ b/packages/pi-skills/package.json
@@ -37,8 +37,8 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@mariozechner/pi-coding-agent": "^0.70.2",
-		"@mariozechner/pi-tui": "^0.70.2"
+		"@mariozechner/pi-coding-agent": "^0.70.5",
+		"@mariozechner/pi-tui": "^0.70.5"
 	},
 	"devDependencies": {
 		"@types/node": "^25.6.0",

--- a/packages/pi-sqlite-tools/package.json
+++ b/packages/pi-sqlite-tools/package.json
@@ -34,7 +34,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@mariozechner/pi-coding-agent": "^0.70.2"
+		"@mariozechner/pi-coding-agent": "^0.70.5"
 	},
 	"devDependencies": {
 		"@types/node": "^25.6.0",

--- a/packages/pi-telemetry/package.json
+++ b/packages/pi-telemetry/package.json
@@ -38,7 +38,7 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@mariozechner/pi-coding-agent": "^0.70.2"
+		"@mariozechner/pi-coding-agent": "^0.70.5"
 	},
 	"devDependencies": {
 		"@types/node": "^25.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
   packages/pi-confirm-destructive:
     dependencies:
       '@mariozechner/pi-coding-agent':
-        specifier: ^0.70.2
-        version: 0.70.2(ws@8.20.0)(zod@4.3.6)
+        specifier: ^0.70.5
+        version: 0.70.5(ws@8.20.0)(zod@4.3.6)
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -86,8 +86,8 @@ importers:
   packages/pi-lsp:
     dependencies:
       '@mariozechner/pi-coding-agent':
-        specifier: ^0.70.2
-        version: 0.70.2(ws@8.20.0)(zod@4.3.6)
+        specifier: ^0.70.5
+        version: 0.70.5(ws@8.20.0)(zod@4.3.6)
       typebox:
         specifier: ^1.1.33
         version: 1.1.33
@@ -105,8 +105,8 @@ importers:
   packages/pi-mcp:
     dependencies:
       '@mariozechner/pi-coding-agent':
-        specifier: ^0.70.2
-        version: 0.70.2(ws@8.20.0)(zod@4.3.6)
+        specifier: ^0.70.5
+        version: 0.70.5(ws@8.20.0)(zod@4.3.6)
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -121,8 +121,8 @@ importers:
   packages/pi-nopeek:
     dependencies:
       '@mariozechner/pi-coding-agent':
-        specifier: ^0.70.2
-        version: 0.70.2(ws@8.20.0)(zod@4.3.6)
+        specifier: ^0.70.5
+        version: 0.70.5(ws@8.20.0)(zod@4.3.6)
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -137,8 +137,8 @@ importers:
   packages/pi-omnisearch:
     dependencies:
       '@mariozechner/pi-coding-agent':
-        specifier: ^0.70.2
-        version: 0.70.2(ws@8.20.0)(zod@4.3.6)
+        specifier: ^0.70.5
+        version: 0.70.5(ws@8.20.0)(zod@4.3.6)
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -153,8 +153,8 @@ importers:
   packages/pi-recall:
     dependencies:
       '@mariozechner/pi-coding-agent':
-        specifier: ^0.70.2
-        version: 0.70.2(ws@8.20.0)(zod@4.3.6)
+        specifier: ^0.70.5
+        version: 0.70.5(ws@8.20.0)(zod@4.3.6)
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -169,11 +169,11 @@ importers:
   packages/pi-redact:
     dependencies:
       '@mariozechner/pi-ai':
-        specifier: ^0.70.2
-        version: 0.70.2(ws@8.20.0)(zod@4.3.6)
+        specifier: ^0.70.5
+        version: 0.70.5(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
-        specifier: ^0.70.2
-        version: 0.70.2(ws@8.20.0)(zod@4.3.6)
+        specifier: ^0.70.5
+        version: 0.70.5(ws@8.20.0)(zod@4.3.6)
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -188,11 +188,11 @@ importers:
   packages/pi-skills:
     dependencies:
       '@mariozechner/pi-coding-agent':
-        specifier: ^0.70.2
-        version: 0.70.2(ws@8.20.0)(zod@4.3.6)
+        specifier: ^0.70.5
+        version: 0.70.5(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui':
-        specifier: ^0.70.2
-        version: 0.70.2
+        specifier: ^0.70.5
+        version: 0.70.5
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -207,8 +207,8 @@ importers:
   packages/pi-sqlite-tools:
     dependencies:
       '@mariozechner/pi-coding-agent':
-        specifier: ^0.70.2
-        version: 0.70.2(ws@8.20.0)(zod@4.3.6)
+        specifier: ^0.70.5
+        version: 0.70.5(ws@8.20.0)(zod@4.3.6)
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -223,8 +223,8 @@ importers:
   packages/pi-telemetry:
     dependencies:
       '@mariozechner/pi-coding-agent':
-        specifier: ^0.70.2
-        version: 0.70.2(ws@8.20.0)(zod@4.3.6)
+        specifier: ^0.70.5
+        version: 0.70.5(ws@8.20.0)(zod@4.3.6)
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -550,37 +550,19 @@ packages:
     resolution: {integrity: sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==}
     hasBin: true
 
-  '@mariozechner/pi-agent-core@0.70.2':
-    resolution: {integrity: sha512-g1hIdKyDwmQOoBGO0R4OhpemKeMENeK0vE5FJtuQKqEcsdCAkVBgZAK6aZUARYZVxMA718JS6WPLFWoddzjD7g==}
-    engines: {node: '>=20.0.0'}
-
   '@mariozechner/pi-agent-core@0.70.5':
     resolution: {integrity: sha512-ZUnJ7fFeJog97KG8FewEyqaObY2sLWvfDurKHl9kImVEbgt3l1LJ9A5pb+4/5KXnCVsoF/Brd0h+7yBEd1Aj5g==}
     engines: {node: '>=20.0.0'}
-
-  '@mariozechner/pi-ai@0.70.2':
-    resolution: {integrity: sha512-+30LRPjXsXF+oI96DvGWMbdPGeqoLJvadh6UPev7wx2DzhC9FEqXkQcoMZ0usbCm7E9pl8ua8a9s/pQ5ikaUbg==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
 
   '@mariozechner/pi-ai@0.70.5':
     resolution: {integrity: sha512-eyeyOfu/YiqzY6q391oRYdmnPIIU1VTKAn3hWIvzqkRHkcArd41/YynG8mw6bgoLdmCnIBoY3fD6nzEHEHLIMA==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
-  '@mariozechner/pi-coding-agent@0.70.2':
-    resolution: {integrity: sha512-asfNqV89HKAmKvJ1wENBY/UQMIf77kLtkzBrvXnMQV4YbH7D/6KT+VeVzPG6zm5PAZP2UtdLY9B9Cge7IxH37w==}
-    engines: {node: '>=20.6.0'}
-    hasBin: true
-
   '@mariozechner/pi-coding-agent@0.70.5':
     resolution: {integrity: sha512-5sQjY2LQLvYfMjo4Dn6P6iy3LFm3MZYgrYmgCQSwQSUM5yqzWceidYYXS4knloW7gNkko+nnhKB2u4NF3w+dVw==}
     engines: {node: '>=20.6.0'}
     hasBin: true
-
-  '@mariozechner/pi-tui@0.70.2':
-    resolution: {integrity: sha512-PtKC0NepnrYcqMx6MXkWTrBzC9tI62KeC6w940oT46lCbfvgmfqXciR15+9BZpxxc1H4jd3CMrKsmOPVeUqZ0A==}
-    engines: {node: '>=20.0.0'}
 
   '@mariozechner/pi-tui@0.70.5':
     resolution: {integrity: sha512-5Ol9weTqpsQ85gg1C6Mo8M8o/HYz4uN7nM7QTPrw/Rm/UoFgO1/T/Irago5aGfzlIj/nmsGcqb7NlkWtT4vXUg==}
@@ -3162,45 +3144,10 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.70.2(ws@8.20.0)(zod@4.3.6)':
-    dependencies:
-      '@mariozechner/pi-ai': 0.70.5(ws@8.20.0)(zod@4.3.6)
-      typebox: 1.1.34
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
   '@mariozechner/pi-agent-core@0.70.5(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/pi-ai': 0.70.5(ws@8.20.0)(zod@4.3.6)
       typebox: 1.1.34
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-ai@0.70.2(ws@8.20.0)(zod@4.3.6)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.90.0(zod@4.3.6)
-      '@aws-sdk/client-bedrock-runtime': 3.1032.0
-      '@google/genai': 1.49.0
-      '@mistralai/mistralai': 2.2.0
-      chalk: 5.6.2
-      openai: 6.26.0(ws@8.20.0)(zod@4.3.6)
-      partial-json: 0.1.7
-      proxy-agent: 6.5.0
-      typebox: 1.1.34
-      undici: 7.24.7
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -3223,40 +3170,6 @@ snapshots:
       typebox: 1.1.34
       undici: 7.24.7
       zod-to-json-schema: 3.25.2(zod@4.3.6)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-coding-agent@0.70.2(ws@8.20.0)(zod@4.3.6)':
-    dependencies:
-      '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.70.2(ws@8.20.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.70.5(ws@8.20.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.70.5
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cli-highlight: 2.1.11
-      diff: 8.0.4
-      extract-zip: 2.0.1
-      file-type: 21.3.4
-      glob: 13.0.6
-      hosted-git-info: 9.0.2
-      ignore: 7.0.5
-      marked: 15.0.12
-      minimatch: 10.2.5
-      proper-lockfile: 4.1.2
-      strip-ansi: 7.2.0
-      typebox: 1.1.34
-      undici: 7.24.7
-      uuid: 14.0.0
-      yaml: 2.8.3
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.3
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -3299,16 +3212,6 @@ snapshots:
       - utf-8-validate
       - ws
       - zod
-
-  '@mariozechner/pi-tui@0.70.2':
-    dependencies:
-      '@types/mime-types': 2.1.4
-      chalk: 5.6.2
-      get-east-asian-width: 1.5.0
-      marked: 15.0.12
-      mime-types: 3.0.2
-    optionalDependencies:
-      koffi: 2.15.6
 
   '@mariozechner/pi-tui@0.70.5':
     dependencies:


### PR DESCRIPTION
## Summary
- cap MCP tool text output at 50 KiB or 2,000 lines
- save full truncated output to a temp file for read/rg inspection
- add tests and docs for oversized MCP responses
- align workspace Pi package dependency versions so root pnpm check passes

Closes #13

## Validation
- pnpm check
- pnpm --filter @spences10/pi-mcp run test
- pnpm --filter @spences10/pi-mcp run check
- pnpm --filter @spences10/pi-mcp run build