### PR TITLE
fix(lsp): invalidate cached diagnostics after file changes

### DIFF
--- a/packages/pi-lsp/src/client.ts
+++ b/packages/pi-lsp/src/client.ts
@@ -241,6 +241,8 @@ export class LspClient extends EventEmitter {
 				textDocument: { uri, version: next_version },
 				contentChanges: [{ text }],
 			});
+			// Invalidate cached diagnostics so wait_for_diagnostics waits for fresh ones
+			this.#diagnostics_by_uri.delete(uri);
 			return;
 		}
 


### PR DESCRIPTION
Fixes #103

## Problem

When calling lsp_diagnostics on a file that has been modified, the first call returns stale diagnostics from before the change. A second call immediately after returns the correct, up-to-date diagnostics.

## Root Cause

In packages/pi-lsp/src/client.ts, the ensure_document_open method sends textDocument/didChange to the language server when file content changes. However, wait_for_diagnostics checks if diagnostics are already cached in #diagnostics_by_uri and returns them immediately, returning stale diagnostics instead of waiting for fresh ones.

## Fix

Invalidate the diagnostics cache when textDocument/didChange is sent, forcing wait_for_diagnostics to wait for fresh diagnostics from the language server.

## Testing

- All existing tests pass (38 tests)
- Manually verified that lsp_diagnostics now returns fresh diagnostics on the first call after file changes

## AI Assistance Disclosure

This fix was developed with the assistance of an AI coding assistant (Qwen3.6 27B, self-hosted) under human supervision. The AI helped identify the root cause, propose the fix, and implement the code changes. All changes were reviewed and verified by a human developer before submission.