### PR TITLE
feat(themes): add STRTGY brand themes

### DIFF
--- a/packages/pi-themes/themes/strtgy-dark.json
+++ b/packages/pi-themes/themes/strtgy-dark.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/src/modes/interactive/theme/theme-schema.json",
+  "name": "strtgy-dark",
+  "vars": {
+    "brand": "#ffe900",
+    "brandDim": "#b3a300",
+    "brandBright": "#fff04d",
+    
+    "successColor": "#3bd23d",
+    "successBg": "#122a13",
+    "successBorder": "#1c4a1d",
+    
+    "info": "#009ccd",
+    "infoDim": "#006d8f",
+    
+    "magenta": "#e838bf",
+    "pink": "#ff48b0",
+    
+    "errorColor": "#ff7477",
+    "errorBg": "#331818",
+    "errorBorder": "#5c2a2b",
+    
+    "warningColor": "#ffaa52",
+    "warningDim": "#b37739",
+    
+    "grayText": "#a0a0a0",
+    "grayMuted": "#606060",
+    "grayDim": "#333333",
+    
+    "bgBase": "#0d0d0d",
+    "bgHighlight": "#1a1a1a",
+    "bgSelection": "#2a2a24",
+    
+    "textMain": "#e0e0e0"
+  },
+  "colors": {
+    "accent": "brand",
+    "border": "grayDim",
+    "borderAccent": "brandDim",
+    "borderMuted": "grayDim",
+    
+    "success": "successColor",
+    "error": "errorColor",
+    "warning": "warningColor",
+    "muted": "grayText",
+    "dim": "grayMuted",
+    "text": "textMain",
+    "thinkingText": "grayText",
+    
+    "selectedBg": "bgSelection",
+    "userMessageBg": "bgHighlight",
+    "userMessageText": "textMain",
+    "customMessageBg": "bgHighlight",
+    "customMessageText": "textMain",
+    "customMessageLabel": "brand",
+    "toolPendingBg": "bgBase",
+    "toolSuccessBg": "successBg",
+    "toolErrorBg": "errorBg",
+    "toolTitle": "brand",
+    "toolOutput": "grayText",
+    
+    "mdHeading": "brand",
+    "mdLink": "info",
+    "mdLinkUrl": "grayMuted",
+    "mdCode": "pink",
+    "mdCodeBlock": "textMain",
+    "mdCodeBlockBorder": "grayDim",
+    "mdQuote": "grayText",
+    "mdQuoteBorder": "brandDim",
+    "mdHr": "grayDim",
+    "mdListBullet": "brand",
+    
+    "toolDiffAdded": "successColor",
+    "toolDiffRemoved": "errorColor",
+    "toolDiffContext": "grayMuted",
+    
+    "syntaxComment": "grayMuted",
+    "syntaxKeyword": "magenta",
+    "syntaxFunction": "info",
+    "syntaxVariable": "warningColor",
+    "syntaxString": "successColor",
+    "syntaxNumber": "pink",
+    "syntaxType": "brandBright",
+    "syntaxOperator": "brand",
+    "syntaxPunctuation": "grayText",
+    
+    "thinkingOff": "grayDim",
+    "thinkingMinimal": "grayMuted",
+    "thinkingLow": "infoDim",
+    "thinkingMedium": "warningDim",
+    "thinkingHigh": "magenta",
+    "thinkingXhigh": "errorColor",
+    
+    "bashMode": "pink"
+  }
+}

--- a/packages/pi-themes/themes/strtgy-post-it-dark.json
+++ b/packages/pi-themes/themes/strtgy-post-it-dark.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/src/modes/interactive/theme/theme-schema.json",
+  "name": "strtgy-post-it-dark",
+  "vars": {
+    "brand": "#ffe900",
+    "brandDim": "#b3a300",
+    
+    "successColor": "#82e384",
+    "successBg": "#1d291e",
+    
+    "info": "#66dbff",
+    
+    "magenta": "#ef76d3",
+    "pink": "#ff66bd",
+    
+    "errorColor": "#ff6669",
+    "errorBg": "#2b1e1e",
+    
+    "warningColor": "#ffb566",
+    
+    "grayText": "#b5b5b0",
+    "grayMuted": "#70706b",
+    "grayDim": "#383833",
+    
+    "bgBase": "#1a1a18",
+    "bgHighlight": "#242421",
+    "bgSelection": "#2e2e26",
+    
+    "textMain": "#e6e6e1"
+  },
+  "colors": {
+    "accent": "brand",
+    "border": "grayDim",
+    "borderAccent": "brandDim",
+    "borderMuted": "grayDim",
+    
+    "success": "successColor",
+    "error": "errorColor",
+    "warning": "warningColor",
+    "muted": "grayText",
+    "dim": "grayMuted",
+    "text": "textMain",
+    "thinkingText": "grayText",
+    
+    "selectedBg": "bgSelection",
+    "userMessageBg": "bgHighlight",
+    "userMessageText": "textMain",
+    "customMessageBg": "bgHighlight",
+    "customMessageText": "textMain",
+    "customMessageLabel": "brand",
+    "toolPendingBg": "bgBase",
+    "toolSuccessBg": "successBg",
+    "toolErrorBg": "errorBg",
+    "toolTitle": "brand",
+    "toolOutput": "grayText",
+    
+    "mdHeading": "brand",
+    "mdLink": "info",
+    "mdLinkUrl": "grayMuted",
+    "mdCode": "pink",
+    "mdCodeBlock": "textMain",
+    "mdCodeBlockBorder": "grayDim",
+    "mdQuote": "grayText",
+    "mdQuoteBorder": "brandDim",
+    "mdHr": "grayDim",
+    "mdListBullet": "brand",
+    
+    "toolDiffAdded": "successColor",
+    "toolDiffRemoved": "errorColor",
+    "toolDiffContext": "grayMuted",
+    
+    "syntaxComment": "grayMuted",
+    "syntaxKeyword": "magenta",
+    "syntaxFunction": "info",
+    "syntaxVariable": "warningColor",
+    "syntaxString": "successColor",
+    "syntaxNumber": "pink",
+    "syntaxType": "brand",
+    "syntaxOperator": "brand",
+    "syntaxPunctuation": "grayText",
+    
+    "thinkingOff": "grayDim",
+    "thinkingMinimal": "grayMuted",
+    "thinkingLow": "info",
+    "thinkingMedium": "warningColor",
+    "thinkingHigh": "magenta",
+    "thinkingXhigh": "errorColor",
+    
+    "bashMode": "pink"
+  }
+}

--- a/packages/pi-themes/themes/strtgy-post-it.json
+++ b/packages/pi-themes/themes/strtgy-post-it.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/src/modes/interactive/theme/theme-schema.json",
+  "name": "strtgy-post-it",
+  "vars": {
+    "brand": "#ffe900",
+    "brandDark": "#b3a300",
+    "brandLight": "#fff04d",
+    
+    "successColor": "#3bd23d",
+    "successDark": "#2a932b",
+    
+    "info": "#009ccd",
+    "infoDark": "#006d8f",
+    
+    "magenta": "#e838bf",
+    "pink": "#ff48b0",
+    
+    "errorColor": "#ff7477",
+    "errorDark": "#b35153",
+    
+    "warningColor": "#ffaa52",
+    "warningDark": "#b37739",
+    
+    "gray": "#888888",
+    "dimGray": "#cccccc",
+    
+    "bgBase": "#f9f9f5",
+    "bgHighlight": "#f0f0ea",
+    "textMain": "#333333",
+    
+    "bgSuccess": "#eafaea",
+    "bgError": "#ffe5e6",
+    
+    "softBrand": "#fffde5",
+    "softBrandBorder": "#fff266"
+  },
+  "colors": {
+    "accent": "brandDark",
+    "border": "dimGray",
+    "borderAccent": "brand",
+    "borderMuted": "dimGray",
+    
+    "success": "successDark",
+    "error": "errorDark",
+    "warning": "warningDark",
+    "muted": "gray",
+    "dim": "gray",
+    "text": "textMain",
+    "thinkingText": "gray",
+    
+    "selectedBg": "softBrand",
+    "userMessageBg": "bgHighlight",
+    "userMessageText": "textMain",
+    "customMessageBg": "bgHighlight",
+    "customMessageText": "textMain",
+    "customMessageLabel": "brandDark",
+    "toolPendingBg": "bgBase",
+    "toolSuccessBg": "bgSuccess",
+    "toolErrorBg": "bgError",
+    "toolTitle": "brandDark",
+    "toolOutput": "textMain",
+    
+    "mdHeading": "brandDark",
+    "mdLink": "infoDark",
+    "mdLinkUrl": "gray",
+    "mdCode": "pink",
+    "mdCodeBlock": "textMain",
+    "mdCodeBlockBorder": "dimGray",
+    "mdQuote": "gray",
+    "mdQuoteBorder": "softBrandBorder",
+    "mdHr": "dimGray",
+    "mdListBullet": "brandDark",
+    
+    "toolDiffAdded": "successDark",
+    "toolDiffRemoved": "errorDark",
+    "toolDiffContext": "gray",
+    
+    "syntaxComment": "gray",
+    "syntaxKeyword": "magenta",
+    "syntaxFunction": "infoDark",
+    "syntaxVariable": "warningDark",
+    "syntaxString": "successDark",
+    "syntaxNumber": "pink",
+    "syntaxType": "brandDark",
+    "syntaxOperator": "brandDark",
+    "syntaxPunctuation": "gray",
+    
+    "thinkingOff": "dimGray",
+    "thinkingMinimal": "gray",
+    "thinkingLow": "info",
+    "thinkingMedium": "warningColor",
+    "thinkingHigh": "magenta",
+    "thinkingXhigh": "errorColor",
+    
+    "bashMode": "pink"
+  }
+}

--- a/packages/pi-themes/themes/strtgy.json
+++ b/packages/pi-themes/themes/strtgy.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/src/modes/interactive/theme/theme-schema.json",
+  "name": "strtgy",
+  "vars": {
+    "brand": "#fff266",
+    "brandDark": "#ccbb00",
+    "brandLight": "#fff799",
+    
+    "successColor": "#82e384",
+    "successBg": "#071d07",
+    
+    "info": "#66dbff",
+    "infoDark": "#007599",
+    
+    "magenta": "#ef76d3",
+    "pink": "#ff66bd",
+    
+    "errorColor": "#ff6669",
+    "errorBg": "#240001",
+    
+    "warningColor": "#ffb566",
+    "warningDark": "#cc6900",
+    
+    "gray": "#888888",
+    "dimGray": "#444444",
+    "bgBase": "#1e1e1e",
+    "bgHighlight": "#2d2d2d"
+  },
+  "colors": {
+    "accent": "brand",
+    "border": "dimGray",
+    "borderAccent": "brandLight",
+    "borderMuted": "dimGray",
+    
+    "success": "successColor",
+    "error": "errorColor",
+    "warning": "warningColor",
+    "muted": "gray",
+    "dim": "dimGray",
+    "text": "",
+    "thinkingText": "gray",
+    
+    "selectedBg": "bgHighlight",
+    "userMessageBg": "bgHighlight",
+    "userMessageText": "",
+    "customMessageBg": "bgHighlight",
+    "customMessageText": "",
+    "customMessageLabel": "brand",
+    "toolPendingBg": "bgBase",
+    "toolSuccessBg": "successBg",
+    "toolErrorBg": "errorBg",
+    "toolTitle": "brand",
+    "toolOutput": "",
+    
+    "mdHeading": "brand",
+    "mdLink": "info",
+    "mdLinkUrl": "gray",
+    "mdCode": "pink",
+    "mdCodeBlock": "",
+    "mdCodeBlockBorder": "dimGray",
+    "mdQuote": "gray",
+    "mdQuoteBorder": "brandDark",
+    "mdHr": "dimGray",
+    "mdListBullet": "brand",
+    
+    "toolDiffAdded": "successColor",
+    "toolDiffRemoved": "errorColor",
+    "toolDiffContext": "gray",
+    
+    "syntaxComment": "gray",
+    "syntaxKeyword": "magenta",
+    "syntaxFunction": "info",
+    "syntaxVariable": "warningColor",
+    "syntaxString": "successColor",
+    "syntaxNumber": "pink",
+    "syntaxType": "brandLight",
+    "syntaxOperator": "brand",
+    "syntaxPunctuation": "dimGray",
+    
+    "thinkingOff": "dimGray",
+    "thinkingMinimal": "gray",
+    "thinkingLow": "infoDark",
+    "thinkingMedium": "warningDark",
+    "thinkingHigh": "magenta",
+    "thinkingXhigh": "errorColor",
+    
+    "bashMode": "pink"
+  }
+}


### PR DESCRIPTION
Added 4 custom STRTGY brand themes for pi:

- `strtgy`: Bright and bold brand colors (Light Mode)
- `strtgy-dark`: Dark mode equivalent of the primary brand theme
- `strtgy-post-it`: Softer pastel version of the brand colors (Light Mode)
- `strtgy-post-it-dark`: Softer pastel version balanced for Dark Mode