### PR TITLE
fix(pi-mcp): expand ${VAR} env vars in HTTP server headers

### DIFF
--- a/packages/pi-mcp/src/config.test.ts
+++ b/packages/pi-mcp/src/config.test.ts
@@ -509,6 +509,78 @@ describe('load_mcp_config', () => {
 		]);
 	});
 
+	it('expands ${VAR} in HTTP headers from process.env', () => {
+		const home = tmp_dir();
+		const cwd = tmp_dir();
+		dirs.push(home, cwd);
+		process.env.HOME = home;
+		process.env.MY_TEST_TOKEN = 'secret123';
+
+		writeFileSync(
+			join(cwd, 'mcp.json'),
+			JSON.stringify({
+				mcpServers: {
+					remote: {
+						type: 'http',
+						url: 'https://example.com/mcp',
+						headers: {
+							Authorization: 'Bearer ${MY_TEST_TOKEN}',
+							'X-Custom': 'static',
+						},
+					},
+				},
+			}),
+		);
+
+		expect(load_mcp_config(cwd)).toEqual([
+			{
+				name: 'remote',
+				transport: 'http',
+				url: 'https://example.com/mcp',
+				headers: {
+					Authorization: 'Bearer secret123',
+					'X-Custom': 'static',
+				},
+			},
+		]);
+
+		delete process.env.MY_TEST_TOKEN;
+	});
+
+	it('expands undefined ${VAR} to empty string', () => {
+		const home = tmp_dir();
+		const cwd = tmp_dir();
+		dirs.push(home, cwd);
+		process.env.HOME = home;
+		delete process.env.NONEXISTENT_VAR;
+
+		writeFileSync(
+			join(cwd, 'mcp.json'),
+			JSON.stringify({
+				mcpServers: {
+					remote: {
+						type: 'http',
+						url: 'https://example.com/mcp',
+						headers: {
+							Authorization: 'Bearer ${NONEXISTENT_VAR}',
+						},
+					},
+				},
+			}),
+		);
+
+		expect(load_mcp_config(cwd)).toEqual([
+			{
+				name: 'remote',
+				transport: 'http',
+				url: 'https://example.com/mcp',
+				headers: {
+					Authorization: 'Bearer ',
+				},
+			},
+		]);
+	});
+
 	it('throws a clear error for invalid config shapes', () => {
 		const home = tmp_dir();
 		const cwd = tmp_dir();

--- a/packages/pi-mcp/src/config/server-parser.ts
+++ b/packages/pi-mcp/src/config/server-parser.ts
@@ -5,6 +5,17 @@ import type {
 	RawMcpServerEntry,
 } from './types.js';
 
+/**
+ * Expand `${VAR}` patterns in a string using process.env.
+ * Returns the string unchanged if no patterns are found.
+ * Undefined/unset env vars expand to an empty string.
+ */
+function expand_env_vars(value: string): string {
+	return value.replace(/\$\{([^}]+)\}/g, (_, varName) => {
+		return process.env[varName] ?? '';
+	});
+}
+
 function is_string_record(
 	value: unknown,
 	label: string,
@@ -61,9 +72,14 @@ export function parse_server(
 			);
 		}
 		is_string_record(entry.headers, 'headers', name);
-		const headers = entry.headers as
+		const raw_headers = entry.headers as
 			| Record<string, string>
 			| undefined;
+		const headers = raw_headers
+			? Object.fromEntries(
+					Object.entries(raw_headers).map(([k, v]) => [k, expand_env_vars(v)]),
+				)
+			: undefined;
 		const config: McpHttpServerConfig = {
 			name,
 			transport: 'http',


### PR DESCRIPTION
## Problem

HTTP MCP server headers in `mcp.json` like `"Authorization": "Bearer ${ZTOKEN}"` were passed through as literal strings instead of being expanded from `process.env`. This caused all HTTP MCP servers using `${VAR}` token references to fail with authentication errors.

## Root Cause

`parse_server()` in `server-parser.ts` copied headers from the raw JSON config as-is without expanding `${ENV_VAR}` patterns. The literal string `"Bearer ${ZTOKEN}"` was sent in the HTTP request, causing the remote MCP server to reject authentication.

## Fix

Added `expand_env_vars()` helper that replaces `${VAR}` patterns with values from `process.env`. Undefined variables expand to empty string (matching standard shell behavior).

The expansion is applied to all header values during server config parsing, before the config is passed to `McpClient`.

## Testing

- Added 2 new test cases:
  - `expands ${VAR} in HTTP headers from process.env` — verifies env vars are expanded while static values pass through unchanged
  - `expands undefined ${VAR} to empty string` — verifies graceful handling of unset variables
- All 58 existing tests continue to pass

## Verification

Before fix — literal string sent:
```
Authorization: Bearer ${ZTOKEN}  →  401: token expired or incorrect
```

After fix — env var expanded:
```
Authorization: Bearer 2ff6ca13...  →  200: valid MCP initialize response
```