### PR TITLE
Add pi-mcp npm bugs metadata

### DIFF
--- a/packages/pi-mcp/package.json
+++ b/packages/pi-mcp/package.json
@@ -9,6 +9,9 @@
 		"pi-package"
 	],
 	"homepage": "https://github.com/spences10/my-pi/tree/main/packages/pi-mcp#readme",
+	"bugs": {
+		"url": "https://github.com/spences10/my-pi/issues"
+	},
 	"license": "MIT",
 	"author": "Scott Spence <me@scottspence.com>",
 	"repository": {


### PR DESCRIPTION
## What changed

Adds the standard npm `bugs.url` metadata field to `packages/pi-mcp/package.json`, pointing to the existing public issue tracker for this repository.

## Why

The published `@spences10/pi-mcp@0.0.39` package already exposes `homepage` and `repository` metadata, but `npm view @spences10/pi-mcp@0.0.39 name version homepage repository bugs --json` currently returns no `bugs` field. Adding it gives npm users and package tooling a direct issue tracker link.

Runtime code is unchanged.

## Validation

```sh
npm view @spences10/pi-mcp@0.0.39 name version homepage repository bugs --json
node metadata smoke check for bugs.url
pnpm install --frozen-lockfile --ignore-scripts
pnpm --filter @spences10/pi-mcp run build
pnpm --filter @spences10/pi-mcp run check
pnpm --filter @spences10/pi-mcp exec npm pack --dry-run --ignore-scripts
git diff --check
```

Note: running `build:self` and `check:self` directly before workspace dependencies were built surfaced existing unresolved workspace dependency/type errors; the package-level `build` and `check` scripts build the dependency packages first and passed.
