### PR TITLE
fix: harden security detection guardrails

### DIFF
--- a/.changeset/secure-guardrails.md
+++ b/.changeset/secure-guardrails.md
@@ -1,0 +1,7 @@
+---
+'@spences10/pi-confirm-destructive': patch
+'@spences10/pi-redact': patch
+---
+
+Harden secret redaction and destructive command detection across
+chunked output, wrappers, aliases, and heredoc input.

--- a/packages/pi-confirm-destructive/README.md
+++ b/packages/pi-confirm-destructive/README.md
@@ -33,17 +33,23 @@ The extension intercepts Pi `tool_call` and `user_bash` events before
 they run and asks for confirmation when an action may destroy data
 that Git cannot restore.
 
-It allows common refactor operations on clean tracked files without
-prompting, while guarding:
+It tokenizes shell command intent across newlines, pipelines, command
+substitutions, groups, and common wrappers such as `sudo`, `env`,
+`command`, `xargs`, and `sh -c`. It allows common refactor operations
+on clean tracked files without prompting, while guarding:
 
-- untracked file deletes or overwrites
-- tracked files with uncommitted changes
-- broad destructive shell commands such as `find -delete`,
-  `git clean`, `rsync --delete`, `truncate`, `dd`, and disk tools
-- destructive Prisma commands such as `prisma migrate reset` and
-  `prisma db push --force-reset`
-- destructive database CLI calls through `psql`, `mysql`, `mariadb`,
-  or `sqlite3`
+- untracked, ignored, or dirty file deletes and overwrites
+- repository-root deletion, including the otherwise clean `.git`
+  directory and local-only branches, stashes, and metadata
+- overwrite redirections and broad destructive shell commands such as
+  `find -delete`/destructive `-exec`, `sed -i`, `git clean`,
+  `rsync --delete`, `truncate`, `dd`, and disk tools
+- destructive Git operations including stash deletion, forced branch
+  deletion, remote-ref deletion, hard resets, and force pushes
+- destructive Prisma and database CLI commands, including `dropdb` and
+  Redis flushes
+- Docker system pruning, Terraform destroy, recursive S3 removal, and
+  Kubernetes deletion
 - custom/MCP tools with destructive names such as `delete`, `drop`,
   `execute_write_query`, or `execute_schema_query`
 
@@ -54,6 +60,12 @@ In interactive mode the prompt offers:
 - `Block`
 
 In non-interactive mode destructive actions are blocked by default.
+
+This is a confirmation guard, not a shell sandbox. Shell aliases,
+dynamically assembled command names, custom executables, and novel
+command families can still hide destructive intent. Keep important
+work committed and backed up, and use OS/container isolation when
+executing untrusted commands.
 
 ## Using from a custom harness
 

--- a/packages/pi-confirm-destructive/src/destructive/assessors.ts
+++ b/packages/pi-confirm-destructive/src/destructive/assessors.ts
@@ -7,69 +7,23 @@ import {
 	is_git_recoverable,
 } from './git.js';
 import { describe_path_risk, is_agent_temp_path } from './paths.js';
-import { extract_command_paths } from './shell.js';
-import type {
-	DestructiveAction,
-	DestructiveCommandPattern,
-} from './types.js';
-
-const DESTRUCTIVE_COMMAND_PATTERNS: DestructiveCommandPattern[] = [
-	{
-		pattern:
-			/(^|[;&|]\s*)(npx\s+|pnpx\s+|pnpm\s+exec\s+|bunx\s+)?prisma\s+(migrate\s+reset|db\s+push\b[^;&|]*--force-reset|db\s+execute\b)/,
-		reason:
-			'Runs a potentially destructive Prisma database operation',
-		allow_key: 'bash:prisma-destructive',
-	},
-	{
-		pattern:
-			/(^|[;&|]\s*)(psql|mysql|mariadb|sqlite3)\b[^;&|]*\b(drop|delete\s+from|truncate|alter\s+table|update\s+\S+\s+set)\b/i,
-		reason: 'Runs destructive SQL through a database CLI',
-		allow_key: 'bash:db-cli-destructive-sql',
-	},
-	{
-		pattern:
-			/(^|[;&|]\s*)find\b[^;&|]*(\s-delete\b|-exec\s+(sudo\s+)?rm\b)/,
-		reason: 'Deletes files found by find',
-		allow_key: 'bash:find-delete',
-	},
-	{
-		pattern:
-			/(^|[;&|]\s*)git\s+clean\b[^;&|]*-[a-zA-Z]*[fdx][a-zA-Z]*/,
-		reason: 'Deletes untracked files or directories',
-		allow_key: 'bash:git-clean',
-	},
-	{
-		pattern:
-			/(^|[;&|]\s*)git\s+(checkout|restore)\b[^;&|]*(\s--\s+\.\s*$|\s\.\s*$)/,
-		reason: 'Discards working tree changes',
-		allow_key: 'bash:git-discard-all',
-	},
-	{
-		pattern: /(^|[;&|]\s*)rsync\b[^;&|]*\s--delete\b/,
-		reason: 'Deletes destination files during sync',
-		allow_key: 'bash:rsync-delete',
-	},
-	{
-		pattern:
-			/(^|[;&|]\s*)truncate\b[^;&|]*(\s-s\s*0\b|\s--size\s*=?\s*0\b)/,
-		reason: 'Empties file contents',
-		allow_key: 'bash:truncate-zero',
-	},
-	{
-		pattern: /(^|[;&|]\s*)dd\b[^;&|]*\bof=/,
-		reason: 'Overwrites a device or file with dd',
-		allow_key: 'bash:dd-output',
-	},
-	{
-		pattern: /(^|[;&|]\s*)(mkfs|fdisk|parted|wipefs)\b/,
-		reason: 'Modifies disks or filesystems',
-		allow_key: 'bash:disk-tool',
-	},
-];
+import {
+	extract_command_paths,
+	extract_overwrite_paths,
+	extract_shell_invocations,
+	type ShellInvocation,
+} from './shell.js';
+import type { DestructiveAction } from './types.js';
 
 const DESTRUCTIVE_CUSTOM_TOOL_NAME =
 	/(^|[_-])(delete|destroy|drop|remove|archive|execute_write_query|execute_schema_query|bulk_insert)([_-]|$)/i;
+const DYNAMIC_PATH_PATTERN = /[*?[$`]|\$\(|\$\{/;
+const SAFE_REDIRECT_TARGETS = new Set([
+	'/dev/null',
+	'/dev/stderr',
+	'/dev/stdout',
+	'/dev/tty',
+]);
 
 function preview(value: string, max = 500): string {
 	const normalized = value.trim().replace(/\s+/g, ' ');
@@ -78,16 +32,53 @@ function preview(value: string, max = 500): string {
 		: normalized;
 }
 
+function destructive_action(
+	command: string,
+	reason: string,
+	allow_key: string,
+	title = 'Confirm destructive command?',
+): DestructiveAction {
+	return {
+		title,
+		description: `${reason}: ${preview(command)}`,
+		reason,
+		allow_key,
+	};
+}
+
+function is_command(
+	invocation: ShellInvocation,
+	command: string,
+): boolean {
+	return invocation.command === command;
+}
+
+function has_sequence(args: string[], sequence: string[]): boolean {
+	const lowered = args.map((arg) => arg.toLowerCase());
+	return lowered.some((_, index) =>
+		sequence.every(
+			(value, offset) => lowered[index + offset] === value,
+		),
+	);
+}
+
+function option_letters(args: string[]): string {
+	return args
+		.filter((arg) => /^-[^-]/.test(arg))
+		.map((arg) => arg.slice(1))
+		.join('');
+}
+
 function assess_rm_command(
 	command: string,
 	cwd: string,
+	invocations: ShellInvocation[],
 	session_created_paths: ReadonlySet<string> = new Set(),
 ): DestructiveAction | undefined {
-	if (
-		!/(^|[;&|]\s*)(sudo\s+)?(rm|rmdir|unlink|shred)\b/.test(command)
-	) {
-		return undefined;
-	}
+	const removes = invocations.filter((invocation) =>
+		['rm', 'rmdir', 'shred', 'unlink'].includes(invocation.command),
+	);
+	if (removes.length === 0) return undefined;
 
 	const paths = extract_command_paths(command, 'rm');
 	if (paths && paths.length > 0) {
@@ -110,26 +101,32 @@ function assess_rm_command(
 	const reason = paths?.length
 		? describe_path_risk(cwd, paths)
 		: 'Deletes files or directories';
-	return {
-		title: 'Confirm destructive command?',
-		description: `${reason}: ${preview(command)}`,
-		reason,
-		allow_key: 'bash:rm-risky',
-	};
+	return destructive_action(command, reason, 'bash:rm-risky');
 }
 
 function assess_git_rm_command(
 	command: string,
 	cwd: string,
+	invocations: ShellInvocation[],
 ): DestructiveAction | undefined {
-	if (!/(^|[;&|]\s*)git\s+rm\b/.test(command)) return undefined;
-	if (/\s-f\b|\s--force\b/.test(command)) {
-		return {
-			title: 'Confirm forced git removal?',
-			description: `Forced git removal can discard uncommitted file changes: ${preview(command)}`,
-			reason: 'Force-removes files from git',
-			allow_key: 'bash:git-rm-force',
-		};
+	const removals = invocations.filter(
+		(invocation) =>
+			is_command(invocation, 'git') && invocation.args[0] === 'rm',
+	);
+	if (removals.length === 0) return undefined;
+	if (
+		removals.some((invocation) =>
+			invocation.args.some(
+				(arg) => arg === '--force' || /^-[^-]*f/.test(arg),
+			),
+		)
+	) {
+		return destructive_action(
+			command,
+			'Force-removes files from git',
+			'bash:git-rm-force',
+			'Confirm forced git removal?',
+		);
 	}
 
 	const paths = extract_command_paths(command, 'git-rm');
@@ -144,48 +141,301 @@ function assess_git_rm_command(
 	const reason = paths?.length
 		? describe_path_risk(cwd, paths)
 		: 'Deletes tracked files from git';
-	return {
-		title: 'Confirm git removal?',
-		description: `${reason}: ${preview(command)}`,
+	return destructive_action(
+		command,
 		reason,
-		allow_key: 'bash:git-rm-risky',
-	};
+		'bash:git-rm-risky',
+		'Confirm git removal?',
+	);
 }
 
 function assess_git_reset_hard(
 	command: string,
 	cwd: string,
+	invocations: ShellInvocation[],
 ): DestructiveAction | undefined {
-	if (!/(^|[;&|]\s*)git\s+reset\b[^;&|]*--hard\b/.test(command)) {
+	const resets_hard = invocations.some(
+		(invocation) =>
+			is_command(invocation, 'git') &&
+			invocation.args[0] === 'reset' &&
+			invocation.args.includes('--hard'),
+	);
+	if (!resets_hard || git(['status', '--porcelain=v1'], cwd) === '') {
 		return undefined;
 	}
-	if (git(['status', '--porcelain=v1'], cwd) === '') return undefined;
-
-	return {
-		title: 'Confirm hard reset?',
-		description: `This can discard uncommitted tracked changes: ${preview(command)}`,
-		reason: 'Discards uncommitted tracked changes',
-		allow_key: 'bash:git-reset-hard',
-	};
+	return destructive_action(
+		command,
+		'Discards uncommitted tracked changes',
+		'bash:git-reset-hard',
+		'Confirm hard reset?',
+	);
 }
 
 function assess_git_force_push(
 	command: string,
+	invocations: ShellInvocation[],
 ): DestructiveAction | undefined {
-	if (
-		!/(^|[;&|]\s*)git\s+push\b[^;&|]*(\s--force(?:-with-lease|-if-includes)?\b|\s-[A-Za-z]*f[A-Za-z]*\b)/.test(
-			command,
-		)
-	) {
-		return undefined;
-	}
+	const force_push = invocations.some(
+		(invocation) =>
+			is_command(invocation, 'git') &&
+			invocation.args[0] === 'push' &&
+			invocation.args.some(
+				(arg) =>
+					arg === '--force' ||
+					arg === '--force-with-lease' ||
+					arg === '--force-if-includes' ||
+					/^-[^-]*f/.test(arg),
+			),
+	);
+	if (!force_push) return undefined;
+	return destructive_action(
+		command,
+		'Overwrites remote git history',
+		'bash:git-force-push',
+		'Confirm force push?',
+	);
+}
 
-	return {
-		title: 'Confirm force push?',
-		description: `This can overwrite remote git history: ${preview(command)}`,
-		reason: 'Overwrites remote git history',
-		allow_key: 'bash:git-force-push',
-	};
+function assess_overwrite_redirect(
+	command: string,
+	cwd: string,
+	session_created_paths: ReadonlySet<string>,
+): DestructiveAction | undefined {
+	const paths = extract_overwrite_paths(command);
+	if (paths.length === 0) return undefined;
+
+	const risky = paths.filter((path) => {
+		if (SAFE_REDIRECT_TARGETS.has(path)) return false;
+		if (DYNAMIC_PATH_PATTERN.test(path)) return true;
+		const absolute = resolve(cwd, path);
+		if (!existsSync(absolute)) return false;
+		return (
+			!session_created_paths.has(absolute) &&
+			!is_agent_temp_path(absolute) &&
+			!is_git_recoverable(cwd, path)
+		);
+	});
+	if (risky.length === 0) return undefined;
+
+	return destructive_action(
+		command,
+		'Truncates or overwrites file contents that git cannot restore',
+		'bash:redirect-overwrite',
+	);
+}
+
+function assess_known_destructive_intent(
+	command: string,
+	invocations: ShellInvocation[],
+): DestructiveAction | undefined {
+	for (const invocation of invocations) {
+		const args = invocation.args;
+		const lower_args = args.map((arg) => arg.toLowerCase());
+		const joined = lower_args.join(' ');
+
+		if (
+			is_command(invocation, 'prisma') &&
+			(has_sequence(lower_args, ['migrate', 'reset']) ||
+				has_sequence(lower_args, ['db', 'execute']) ||
+				(has_sequence(lower_args, ['db', 'push']) &&
+					lower_args.includes('--force-reset')))
+		) {
+			return destructive_action(
+				command,
+				'Runs a potentially destructive Prisma database operation',
+				'bash:prisma-destructive',
+			);
+		}
+		if (
+			['psql', 'mysql', 'mariadb', 'sqlite3'].includes(
+				invocation.command,
+			) &&
+			/\b(drop|delete\s+from|truncate|alter\s+table|update\s+\S+\s+set)\b/i.test(
+				joined,
+			)
+		) {
+			return destructive_action(
+				command,
+				'Runs destructive SQL through a database CLI',
+				'bash:db-cli-destructive-sql',
+			);
+		}
+		if (
+			is_command(invocation, 'find') &&
+			lower_args.includes('-delete')
+		) {
+			return destructive_action(
+				command,
+				'Deletes files found by find',
+				'bash:find-delete',
+			);
+		}
+		if (
+			is_command(invocation, 'git') &&
+			lower_args[0] === 'clean' &&
+			option_letters(lower_args.slice(1)).includes('f')
+		) {
+			return destructive_action(
+				command,
+				'Deletes untracked files or directories',
+				'bash:git-clean',
+			);
+		}
+		if (
+			is_command(invocation, 'git') &&
+			['checkout', 'restore'].includes(lower_args[0] ?? '') &&
+			lower_args.at(-1) === '.'
+		) {
+			return destructive_action(
+				command,
+				'Discards working tree changes',
+				'bash:git-discard-all',
+			);
+		}
+		if (
+			is_command(invocation, 'rsync') &&
+			lower_args.includes('--delete')
+		) {
+			return destructive_action(
+				command,
+				'Deletes destination files during sync',
+				'bash:rsync-delete',
+			);
+		}
+		if (
+			is_command(invocation, 'truncate') &&
+			/(?:^|\s)(?:-s\s*0|--size(?:=|\s+)0)(?:\s|$)/.test(joined)
+		) {
+			return destructive_action(
+				command,
+				'Empties file contents',
+				'bash:truncate-zero',
+			);
+		}
+		if (
+			is_command(invocation, 'dd') &&
+			lower_args.some((arg) => arg.startsWith('of='))
+		) {
+			return destructive_action(
+				command,
+				'Overwrites a device or file with dd',
+				'bash:dd-output',
+			);
+		}
+		if (
+			['mkfs', 'fdisk', 'parted', 'wipefs'].includes(
+				invocation.command,
+			)
+		) {
+			return destructive_action(
+				command,
+				'Modifies disks or filesystems',
+				'bash:disk-tool',
+			);
+		}
+		if (
+			is_command(invocation, 'sed') &&
+			lower_args.some((arg) => arg === '-i' || arg.startsWith('-i'))
+		) {
+			return destructive_action(
+				command,
+				'Edits files in place with sed',
+				'bash:sed-in-place',
+			);
+		}
+		if (
+			is_command(invocation, 'git') &&
+			lower_args[0] === 'stash' &&
+			['drop', 'clear'].includes(lower_args[1] ?? '')
+		) {
+			return destructive_action(
+				command,
+				'Deletes git stash entries',
+				'bash:git-stash-delete',
+			);
+		}
+		if (
+			is_command(invocation, 'git') &&
+			lower_args[0] === 'branch' &&
+			args.includes('-D')
+		) {
+			return destructive_action(
+				command,
+				'Force-deletes a git branch',
+				'bash:git-branch-force-delete',
+			);
+		}
+		if (
+			is_command(invocation, 'git') &&
+			lower_args[0] === 'push' &&
+			lower_args.includes('--delete')
+		) {
+			return destructive_action(
+				command,
+				'Deletes a remote git ref',
+				'bash:git-push-delete',
+			);
+		}
+		if (
+			is_command(invocation, 'docker') &&
+			has_sequence(lower_args, ['system', 'prune'])
+		) {
+			return destructive_action(
+				command,
+				'Deletes unused Docker data',
+				'bash:docker-system-prune',
+			);
+		}
+		if (is_command(invocation, 'dropdb')) {
+			return destructive_action(
+				command,
+				'Drops a PostgreSQL database',
+				'bash:dropdb',
+			);
+		}
+		if (
+			is_command(invocation, 'redis-cli') &&
+			lower_args.some((arg) => ['flushall', 'flushdb'].includes(arg))
+		) {
+			return destructive_action(
+				command,
+				'Deletes Redis database contents',
+				'bash:redis-flush',
+			);
+		}
+		if (
+			is_command(invocation, 'terraform') &&
+			lower_args.includes('destroy')
+		) {
+			return destructive_action(
+				command,
+				'Destroys Terraform-managed infrastructure',
+				'bash:terraform-destroy',
+			);
+		}
+		if (
+			is_command(invocation, 'aws') &&
+			has_sequence(lower_args, ['s3', 'rm']) &&
+			lower_args.includes('--recursive')
+		) {
+			return destructive_action(
+				command,
+				'Recursively deletes S3 objects',
+				'bash:aws-s3-rm-recursive',
+			);
+		}
+		if (
+			is_command(invocation, 'kubectl') &&
+			lower_args.includes('delete')
+		) {
+			return destructive_action(
+				command,
+				'Deletes Kubernetes resources',
+				'bash:kubectl-delete',
+			);
+		}
+	}
+	return undefined;
 }
 
 export function assess_bash_command(
@@ -195,25 +445,25 @@ export function assess_bash_command(
 ): DestructiveAction | undefined {
 	const normalized = command.trim();
 	if (!normalized) return undefined;
+	const invocations = extract_shell_invocations(normalized);
 
-	const specific =
-		assess_rm_command(normalized, cwd, session_created_paths) ??
-		assess_git_rm_command(normalized, cwd) ??
-		assess_git_reset_hard(normalized, cwd) ??
-		assess_git_force_push(normalized);
-	if (specific) return specific;
-
-	const match = DESTRUCTIVE_COMMAND_PATTERNS.find(({ pattern }) =>
-		pattern.test(normalized),
+	return (
+		assess_rm_command(
+			normalized,
+			cwd,
+			invocations,
+			session_created_paths,
+		) ??
+		assess_git_rm_command(normalized, cwd, invocations) ??
+		assess_git_reset_hard(normalized, cwd, invocations) ??
+		assess_git_force_push(normalized, invocations) ??
+		assess_overwrite_redirect(
+			normalized,
+			cwd,
+			session_created_paths,
+		) ??
+		assess_known_destructive_intent(normalized, invocations)
 	);
-	if (!match) return undefined;
-
-	return {
-		title: 'Confirm destructive command?',
-		description: `${match.reason}: ${preview(normalized)}`,
-		reason: match.reason,
-		allow_key: match.allow_key,
-	};
 }
 
 function assess_file_write(
@@ -260,12 +510,10 @@ function assess_file_edit(
 		if (typeof new_text === 'string') added_chars += new_text.length;
 	}
 
-	if (removed_chars === 0 || removed_chars - added_chars < 200) {
+	if (removed_chars === 0 || removed_chars - added_chars < 200)
 		return undefined;
-	}
-	if (path && session_created_paths.has(resolve(cwd, path))) {
+	if (path && session_created_paths.has(resolve(cwd, path)))
 		return undefined;
-	}
 	if (path && is_git_recoverable(cwd, path)) return undefined;
 
 	return {
@@ -281,9 +529,8 @@ function assess_file_edit(
 function assess_custom_tool(
 	event: ToolCallEvent,
 ): DestructiveAction | undefined {
-	if (!DESTRUCTIVE_CUSTOM_TOOL_NAME.test(event.toolName)) {
+	if (!DESTRUCTIVE_CUSTOM_TOOL_NAME.test(event.toolName))
 		return undefined;
-	}
 
 	const input = event.input as Record<string, unknown>;
 	const query =

--- a/packages/pi-confirm-destructive/src/destructive/assessors.ts
+++ b/packages/pi-confirm-destructive/src/destructive/assessors.ts
@@ -273,7 +273,8 @@ function assess_known_destructive_intent(
 		if (
 			is_command(invocation, 'git') &&
 			lower_args[0] === 'clean' &&
-			option_letters(lower_args.slice(1)).includes('f')
+			(lower_args.includes('--force') ||
+				option_letters(lower_args.slice(1)).includes('f'))
 		) {
 			return destructive_action(
 				command,
@@ -335,7 +336,13 @@ function assess_known_destructive_intent(
 		}
 		if (
 			is_command(invocation, 'sed') &&
-			lower_args.some((arg) => arg === '-i' || arg.startsWith('-i'))
+			lower_args.some(
+				(arg) =>
+					arg === '-i' ||
+					arg.startsWith('-i') ||
+					arg === '--in-place' ||
+					arg.startsWith('--in-place='),
+			)
 		) {
 			return destructive_action(
 				command,
@@ -357,7 +364,11 @@ function assess_known_destructive_intent(
 		if (
 			is_command(invocation, 'git') &&
 			lower_args[0] === 'branch' &&
-			args.includes('-D')
+			(args.includes('-D') ||
+				(lower_args.includes('--delete') &&
+					lower_args.includes('--force')) ||
+				(option_letters(lower_args.slice(1)).includes('d') &&
+					option_letters(lower_args.slice(1)).includes('f')))
 		) {
 			return destructive_action(
 				command,
@@ -368,7 +379,9 @@ function assess_known_destructive_intent(
 		if (
 			is_command(invocation, 'git') &&
 			lower_args[0] === 'push' &&
-			lower_args.includes('--delete')
+			(lower_args.includes('--delete') ||
+				option_letters(lower_args.slice(1)).includes('d') ||
+				lower_args.some((arg) => /^:[^:]/.test(arg)))
 		) {
 			return destructive_action(
 				command,

--- a/packages/pi-confirm-destructive/src/destructive/git.ts
+++ b/packages/pi-confirm-destructive/src/destructive/git.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import { isAbsolute, relative, resolve } from 'node:path';
 import type { GitRecoverability } from './types.js';
 
 export function git(args: string[], cwd: string): string | undefined {
@@ -16,11 +17,23 @@ function is_git_repo(cwd: string): boolean {
 	return git(['rev-parse', '--is-inside-work-tree'], cwd) === 'true';
 }
 
+function is_same_or_parent(parent: string, child: string): boolean {
+	const rel = relative(resolve(parent), resolve(child));
+	return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+function deletes_repository_root(cwd: string, path: string): boolean {
+	const root = git(['rev-parse', '--show-toplevel'], cwd);
+	if (!root) return false;
+	return is_same_or_parent(resolve(cwd, path), root);
+}
+
 export function get_git_recoverability(
 	cwd: string,
 	path: string,
 ): GitRecoverability {
 	if (!is_git_repo(cwd)) return 'not-git';
+	if (deletes_repository_root(cwd, path)) return 'repo-root';
 
 	const status = git(['status', '--porcelain=v1', '--', path], cwd);
 	if (status === undefined) return 'not-git';
@@ -29,6 +42,19 @@ export function get_git_recoverability(
 			? 'untracked'
 			: 'tracked-dirty';
 	}
+
+	const ignored = git(
+		[
+			'ls-files',
+			'--others',
+			'--ignored',
+			'--exclude-standard',
+			'--',
+			path,
+		],
+		cwd,
+	);
+	if (ignored) return 'ignored';
 
 	const tracked = git(['ls-files', '--', path], cwd);
 	return tracked ? 'tracked-clean' : 'untracked';

--- a/packages/pi-confirm-destructive/src/destructive/paths.ts
+++ b/packages/pi-confirm-destructive/src/destructive/paths.ts
@@ -38,6 +38,12 @@ export function describe_path_risk(
 	const risks = new Set(
 		risky.map((path) => get_git_recoverability(cwd, path)),
 	);
+	if (risks.has('repo-root')) {
+		return 'Deletes the repository root, including git metadata';
+	}
+	if (risks.has('ignored')) {
+		return 'Deletes ignored files or directories that git cannot restore';
+	}
 	if (risks.has('untracked')) {
 		return 'Deletes untracked files or directories that git cannot restore';
 	}

--- a/packages/pi-confirm-destructive/src/destructive/shell.ts
+++ b/packages/pi-confirm-destructive/src/destructive/shell.ts
@@ -41,6 +41,106 @@ const SIMPLE_WRAPPERS = new Set(['command', 'exec', 'nohup']);
 const SHELL_COMMANDS = new Set(['bash', 'dash', 'ksh', 'sh', 'zsh']);
 const RUNNERS = new Set(['bunx', 'npx', 'pnpx']);
 
+interface HeredocDelimiter {
+	value: string;
+	strip_tabs: boolean;
+}
+
+function heredoc_delimiters(line: string): HeredocDelimiter[] {
+	const delimiters: HeredocDelimiter[] = [];
+	let single_quoted = false;
+	let double_quoted = false;
+
+	for (let index = 0; index < line.length; index += 1) {
+		const character = line[index];
+		if (character === '\\') {
+			index += 1;
+			continue;
+		}
+		if (character === "'" && !double_quoted) {
+			single_quoted = !single_quoted;
+			continue;
+		}
+		if (character === '"' && !single_quoted) {
+			double_quoted = !double_quoted;
+			continue;
+		}
+		if (single_quoted || double_quoted) continue;
+		if (
+			character === '#' &&
+			(index === 0 || /\s/.test(line[index - 1]))
+		)
+			break;
+		if (
+			character !== '<' ||
+			line[index + 1] !== '<' ||
+			line[index + 2] === '<'
+		) {
+			continue;
+		}
+
+		index += 2;
+		const strip_tabs = line[index] === '-';
+		if (strip_tabs) index += 1;
+		while (/\s/.test(line[index] ?? '')) index += 1;
+
+		let value = '';
+		let quoted: "'" | '"' | undefined;
+		for (; index < line.length; index += 1) {
+			const delimiter_character = line[index];
+			if (quoted) {
+				if (delimiter_character === quoted) {
+					quoted = undefined;
+				} else if (delimiter_character === '\\' && quoted === '"') {
+					if (index + 1 < line.length) value += line[++index];
+				} else {
+					value += delimiter_character;
+				}
+				continue;
+			}
+			if (
+				delimiter_character === "'" ||
+				delimiter_character === '"'
+			) {
+				quoted = delimiter_character;
+				continue;
+			}
+			if (delimiter_character === '\\') {
+				if (index + 1 < line.length) value += line[++index];
+				continue;
+			}
+			if (
+				/\s/.test(delimiter_character) ||
+				';&|()<>'.includes(delimiter_character)
+			)
+				break;
+			value += delimiter_character;
+		}
+		if (value) delimiters.push({ value, strip_tabs });
+	}
+
+	return delimiters;
+}
+
+function strip_heredoc_bodies(command: string): string {
+	const pending: HeredocDelimiter[] = [];
+	return command
+		.split(/\r?\n/)
+		.map((line) => {
+			const active = pending[0];
+			if (active) {
+				const candidate = active.strip_tabs
+					? line.replace(/^\t+/, '')
+					: line;
+				if (candidate === active.value) pending.shift();
+				return '';
+			}
+			pending.push(...heredoc_delimiters(line));
+			return line;
+		})
+		.join('\n');
+}
+
 function tokenize_shell(command: string): ShellToken[] {
 	const tokens: ShellToken[] = [];
 	let word = '';
@@ -224,6 +324,45 @@ function unwrap_command(
 			index = skip_options(words, index + 1);
 			continue;
 		}
+		if (current === 'nice') {
+			index = skip_options(
+				words,
+				index + 1,
+				new Set(['-n', '--adjustment']),
+			);
+			continue;
+		}
+		if (current === 'ionice') {
+			index = skip_options(
+				words,
+				index + 1,
+				new Set([
+					'-c',
+					'-n',
+					'-p',
+					'-P',
+					'-u',
+					'--class',
+					'--classdata',
+					'--pid',
+					'--pgid',
+					'--uid',
+				]),
+			);
+			continue;
+		}
+		if (current === 'stdbuf') {
+			index = skip_options(
+				words,
+				index + 1,
+				new Set(['-e', '-i', '-o', '--error', '--input', '--output']),
+			);
+			continue;
+		}
+		if (current === 'setsid' || current === 'busybox') {
+			index = skip_options(words, index + 1);
+			continue;
+		}
 		if (current === 'pnpm' && words[index + 1] === 'exec') {
 			index = skip_options(words, index + 2);
 			continue;
@@ -389,7 +528,8 @@ function embedded_command_texts(command: string): string[] {
 export function extract_shell_invocations(
 	command: string,
 ): ShellInvocation[] {
-	const tokens = tokenize_shell(command);
+	const prepared_command = strip_heredoc_bodies(command);
+	const tokens = tokenize_shell(prepared_command);
 	const invocations: ShellInvocation[] = [];
 	let segment: ShellToken[] = [];
 
@@ -411,7 +551,7 @@ export function extract_shell_invocations(
 		segment.push(token);
 	}
 	flush_segment();
-	for (const embedded of embedded_command_texts(command)) {
+	for (const embedded of embedded_command_texts(prepared_command)) {
 		invocations.push(...extract_shell_invocations(embedded));
 	}
 	return invocations;

--- a/packages/pi-confirm-destructive/src/destructive/shell.ts
+++ b/packages/pi-confirm-destructive/src/destructive/shell.ts
@@ -1,72 +1,505 @@
 import type { ToolResultEvent } from '@earendil-works/pi-coding-agent';
 import { existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { basename, resolve } from 'node:path';
 import { is_temp_path } from './paths.js';
 
-function parse_shell_words(command: string): string[] {
-	const words: string[] = [];
-	const pattern = /"((?:\\.|[^"])*)"|'([^']*)'|(\S+)/g;
-	let match: RegExpExecArray | null;
-	while ((match = pattern.exec(command))) {
-		words.push(match[1] ?? match[2] ?? match[3]);
+interface ShellToken {
+	kind: 'word' | 'operator';
+	value: string;
+}
+
+export interface ShellInvocation {
+	command: string;
+	args: string[];
+}
+
+const CONTROL_OPERATORS = new Set([
+	';',
+	'\n',
+	'&',
+	'&&',
+	'|',
+	'||',
+	'(',
+	')',
+	'{',
+	'}',
+]);
+const REDIRECT_OPERATORS = new Set(['>', '>|', '1>', '2>', '&>']);
+const LEADING_SHELL_KEYWORDS = new Set([
+	'!',
+	'do',
+	'done',
+	'elif',
+	'else',
+	'if',
+	'then',
+	'until',
+	'while',
+]);
+const SIMPLE_WRAPPERS = new Set(['command', 'exec', 'nohup']);
+const SHELL_COMMANDS = new Set(['bash', 'dash', 'ksh', 'sh', 'zsh']);
+const RUNNERS = new Set(['bunx', 'npx', 'pnpx']);
+
+function tokenize_shell(command: string): ShellToken[] {
+	const tokens: ShellToken[] = [];
+	let word = '';
+
+	const flush_word = () => {
+		if (!word) return;
+		tokens.push({ kind: 'word', value: word });
+		word = '';
+	};
+
+	for (let index = 0; index < command.length; index += 1) {
+		const character = command[index];
+
+		if (character === "'" || character === '"') {
+			const quote = character;
+			for (index += 1; index < command.length; index += 1) {
+				const quoted = command[index];
+				if (quoted === quote) break;
+				if (
+					quote === '"' &&
+					quoted === '\\' &&
+					index + 1 < command.length
+				) {
+					word += command[index + 1];
+					index += 1;
+					continue;
+				}
+				word += quoted;
+			}
+			continue;
+		}
+
+		if (character === '\\' && index + 1 < command.length) {
+			word += command[index + 1];
+			index += 1;
+			continue;
+		}
+
+		if (character === '\n' || character === '\r') {
+			flush_word();
+			if (tokens.at(-1)?.value !== '\n') {
+				tokens.push({ kind: 'operator', value: '\n' });
+			}
+			if (character === '\r' && command[index + 1] === '\n')
+				index += 1;
+			continue;
+		}
+
+		if (/\s/.test(character)) {
+			flush_word();
+			continue;
+		}
+
+		if (';&|(){}<>'.includes(character)) {
+			flush_word();
+			let operator = character;
+			const next = command[index + 1];
+			if (
+				(character === '&' && (next === '&' || next === '>')) ||
+				(character === '|' && (next === '|' || next === '>')) ||
+				(character === '>' && (next === '>' || next === '|')) ||
+				(character === '<' && next === '<')
+			) {
+				operator += next;
+				index += 1;
+			}
+			const previous = tokens.at(-1);
+			if (
+				operator === '>' &&
+				previous?.kind === 'word' &&
+				/^[012]$/.test(previous.value)
+			) {
+				operator = `${previous.value}>`;
+				tokens.pop();
+			}
+			tokens.push({ kind: 'operator', value: operator });
+			continue;
+		}
+
+		word += character;
 	}
-	return words;
+
+	flush_word();
+	return tokens;
+}
+
+function command_name(value: string): string {
+	return basename(value).toLowerCase();
+}
+
+function is_assignment(word: string): boolean {
+	return /^[A-Za-z_][A-Za-z0-9_]*=/.test(word);
+}
+
+function skip_options(
+	words: string[],
+	start: number,
+	options_with_values: ReadonlySet<string> = new Set(),
+): number {
+	let index = start;
+	while (index < words.length) {
+		const word = words[index];
+		if (word === '--') return index + 1;
+		if (!word.startsWith('-') || word === '-') return index;
+		if (options_with_values.has(word)) index += 1;
+		index += 1;
+	}
+	return index;
+}
+
+function unwrap_command(
+	words: string[],
+): ShellInvocation | undefined {
+	let index = 0;
+	while (
+		index < words.length &&
+		(LEADING_SHELL_KEYWORDS.has(words[index].toLowerCase()) ||
+			is_assignment(words[index]))
+	) {
+		index += 1;
+	}
+
+	for (;;) {
+		while (index < words.length && is_assignment(words[index]))
+			index += 1;
+		const current = command_name(words[index] ?? '');
+		if (!current) return undefined;
+
+		if (current === 'sudo') {
+			index = skip_options(
+				words,
+				index + 1,
+				new Set([
+					'-C',
+					'-D',
+					'-g',
+					'-h',
+					'-p',
+					'-R',
+					'-r',
+					'-T',
+					'-t',
+					'-u',
+					'--chdir',
+					'--group',
+					'--host',
+					'--prompt',
+					'--role',
+					'--type',
+					'--user',
+				]),
+			);
+			continue;
+		}
+		if (current === 'env') {
+			index = skip_options(
+				words,
+				index + 1,
+				new Set([
+					'-C',
+					'-S',
+					'-u',
+					'--chdir',
+					'--split-string',
+					'--unset',
+				]),
+			);
+			while (index < words.length && is_assignment(words[index]))
+				index += 1;
+			continue;
+		}
+		if (SIMPLE_WRAPPERS.has(current)) {
+			index = skip_options(words, index + 1);
+			continue;
+		}
+		if (current === 'time') {
+			index = skip_options(words, index + 1, new Set(['-f', '-o']));
+			continue;
+		}
+		if (RUNNERS.has(current)) {
+			index = skip_options(words, index + 1);
+			continue;
+		}
+		if (current === 'pnpm' && words[index + 1] === 'exec') {
+			index = skip_options(words, index + 2);
+			continue;
+		}
+		if (current === 'git') {
+			const args = words.slice(index + 1);
+			const command_index = skip_options(
+				args,
+				0,
+				new Set([
+					'-C',
+					'-c',
+					'--config-env',
+					'--exec-path',
+					'--git-dir',
+					'--namespace',
+					'--work-tree',
+				]),
+			);
+			return { command: current, args: args.slice(command_index) };
+		}
+
+		return { command: current, args: words.slice(index + 1) };
+	}
+}
+
+function xargs_command(args: string[]): ShellInvocation | undefined {
+	let index = skip_options(
+		args,
+		0,
+		new Set(['-a', '-d', '-E', '-I', '-L', '-n', '-P', '-s']),
+	);
+	while (index < args.length && is_assignment(args[index]))
+		index += 1;
+	return unwrap_command(args.slice(index));
+}
+
+function nested_find_commands(args: string[]): ShellInvocation[] {
+	const nested: ShellInvocation[] = [];
+	for (let index = 0; index < args.length; index += 1) {
+		if (args[index] !== '-exec' && args[index] !== '-execdir')
+			continue;
+		const end = args.findIndex(
+			(word, candidate) =>
+				candidate > index && (word === ';' || word === '+'),
+		);
+		const words = args.slice(index + 1, end === -1 ? undefined : end);
+		const invocation = unwrap_command(words);
+		if (invocation) nested.push(...expand_invocation(invocation));
+		if (end !== -1) index = end;
+	}
+	return nested;
+}
+
+function expand_invocation(
+	invocation: ShellInvocation,
+): ShellInvocation[] {
+	const invocations = [invocation];
+	if (SHELL_COMMANDS.has(invocation.command)) {
+		const command_index = invocation.args.findIndex(
+			(arg) => arg === '--command' || /^-[^-]*c/.test(arg),
+		);
+		const payload = invocation.args[command_index + 1];
+		if (command_index !== -1 && payload) {
+			invocations.push(...extract_shell_invocations(payload));
+		}
+	}
+	if (invocation.command === 'eval' && invocation.args.length > 0) {
+		invocations.push(
+			...extract_shell_invocations(invocation.args.join(' ')),
+		);
+	}
+	if (invocation.command === 'xargs') {
+		const nested = xargs_command(invocation.args);
+		if (nested) invocations.push(...expand_invocation(nested));
+	}
+	if (invocation.command === 'find') {
+		invocations.push(...nested_find_commands(invocation.args));
+	}
+	return invocations;
+}
+
+function invocations_from_segment(
+	segment: ShellToken[],
+): ShellInvocation[] {
+	const words = segment
+		.filter((token) => token.kind === 'word')
+		.map((token) => token.value);
+	const invocation = unwrap_command(words);
+	return invocation ? expand_invocation(invocation) : [];
+}
+
+function embedded_command_texts(command: string): string[] {
+	const embedded: string[] = [];
+	let single_quoted = false;
+	let double_quoted = false;
+
+	for (let index = 0; index < command.length; index += 1) {
+		const character = command[index];
+		if (character === '\\') {
+			index += 1;
+			continue;
+		}
+		if (character === "'" && !double_quoted) {
+			single_quoted = !single_quoted;
+			continue;
+		}
+		if (character === '"' && !single_quoted) {
+			double_quoted = !double_quoted;
+			continue;
+		}
+		if (single_quoted) continue;
+
+		if (character === '`') {
+			let end = index + 1;
+			while (end < command.length) {
+				if (command[end] === '\\') {
+					end += 2;
+					continue;
+				}
+				if (command[end] === '`') break;
+				end += 1;
+			}
+			if (end < command.length) {
+				embedded.push(command.slice(index + 1, end));
+				index = end;
+			}
+			continue;
+		}
+
+		if (character !== '$' || command[index + 1] !== '(') continue;
+		let depth = 1;
+		let end = index + 2;
+		let nested_single = false;
+		let nested_double = false;
+		for (; end < command.length; end += 1) {
+			const nested = command[end];
+			if (nested === '\\') {
+				end += 1;
+				continue;
+			}
+			if (nested === "'" && !nested_double) {
+				nested_single = !nested_single;
+				continue;
+			}
+			if (nested === '"' && !nested_single) {
+				nested_double = !nested_double;
+				continue;
+			}
+			if (nested_single) continue;
+			if (nested === '(') depth += 1;
+			if (nested === ')') depth -= 1;
+			if (depth === 0) break;
+		}
+		if (depth === 0) {
+			embedded.push(command.slice(index + 2, end));
+			index = end;
+		}
+	}
+	return embedded;
+}
+
+export function extract_shell_invocations(
+	command: string,
+): ShellInvocation[] {
+	const tokens = tokenize_shell(command);
+	const invocations: ShellInvocation[] = [];
+	let segment: ShellToken[] = [];
+
+	const flush_segment = () => {
+		if (segment.length > 0) {
+			invocations.push(...invocations_from_segment(segment));
+			segment = [];
+		}
+	};
+
+	for (const token of tokens) {
+		if (
+			token.kind === 'operator' &&
+			CONTROL_OPERATORS.has(token.value)
+		) {
+			flush_segment();
+			continue;
+		}
+		segment.push(token);
+	}
+	flush_segment();
+	for (const embedded of embedded_command_texts(command)) {
+		invocations.push(...extract_shell_invocations(embedded));
+	}
+	return invocations;
+}
+
+function paths_from_invocation(
+	invocation: ShellInvocation,
+): string[] {
+	const offset =
+		invocation.command === 'git' && invocation.args[0] === 'rm'
+			? 1
+			: 0;
+	return invocation.args
+		.slice(offset)
+		.filter(
+			(word) =>
+				word !== '--' &&
+				word !== ';' &&
+				word !== '+' &&
+				word !== '{}' &&
+				!word.startsWith('-'),
+		);
 }
 
 export function extract_command_paths(
 	command: string,
-	command_name: 'rm' | 'git-rm',
+	command_name_to_find: 'rm' | 'git-rm',
 ): string[] | undefined {
-	if (/[;&|`$()<>]/.test(command)) return undefined;
-	const words = parse_shell_words(command);
-	const command_index =
-		command_name === 'rm'
-			? words.findIndex((word) =>
-					['rm', 'rmdir', 'unlink', 'shred'].includes(word),
-				)
-			: words.findIndex(
-					(word, index) =>
-						word === 'rm' && words[index - 1] === 'git',
-				);
-	if (command_index === -1) return undefined;
+	const invocations = extract_shell_invocations(command).filter(
+		(invocation) =>
+			command_name_to_find === 'rm'
+				? ['rm', 'rmdir', 'shred', 'unlink'].includes(
+						invocation.command,
+					)
+				: invocation.command === 'git' && invocation.args[0] === 'rm',
+	);
+	if (invocations.length === 0) return undefined;
+	return invocations.flatMap(paths_from_invocation);
+}
 
-	return words
-		.slice(command_index + 1)
-		.filter((word) => word !== '--' && !word.startsWith('-'));
+export function extract_overwrite_paths(command: string): string[] {
+	const tokens = tokenize_shell(command);
+	const paths: string[] = [];
+	for (let index = 0; index < tokens.length; index += 1) {
+		const token = tokens[index];
+		if (
+			token.kind !== 'operator' ||
+			!REDIRECT_OPERATORS.has(token.value)
+		) {
+			continue;
+		}
+		const target = tokens[index + 1];
+		if (target?.kind === 'word') paths.push(target.value);
+	}
+	return paths;
 }
 
 function option_takes_value(
-	command_name: string,
+	command_name_to_check: string,
 	option: string,
 ): boolean {
 	const value_options: Record<string, string[]> = {
 		mkdir: ['-m', '--mode', '-Z', '--context'],
 		touch: ['-r', '--reference', '-d', '--date', '-t'],
 	};
-	return value_options[command_name]?.includes(option) ?? false;
+	return (
+		value_options[command_name_to_check]?.includes(option) ?? false
+	);
 }
 
 function extract_simple_create_paths(
 	command: string,
 	cwd: string,
 ): string[] {
-	if (/[;&|`$()<>]/.test(command)) return [];
-	const words = parse_shell_words(command);
-	const command_name = words[0];
-	if (!['mkdir', 'touch'].includes(command_name)) return [];
-
+	const invocations = extract_shell_invocations(command);
 	const paths: string[] = [];
-	for (let index = 1; index < words.length; index += 1) {
-		const word = words[index];
-		if (!word || word === '--') continue;
-		if (word.startsWith('-')) {
-			if (option_takes_value(command_name, word)) index += 1;
-			continue;
-		}
-
-		const absolute = resolve(cwd, word);
-		if (is_temp_path(absolute) && !existsSync(absolute)) {
-			paths.push(absolute);
+	for (const invocation of invocations) {
+		if (!['mkdir', 'touch'].includes(invocation.command)) continue;
+		for (let index = 0; index < invocation.args.length; index += 1) {
+			const word = invocation.args[index];
+			if (!word || word === '--') continue;
+			if (word.startsWith('-')) {
+				if (option_takes_value(invocation.command, word)) index += 1;
+				continue;
+			}
+			const absolute = resolve(cwd, word);
+			if (is_temp_path(absolute) && !existsSync(absolute))
+				paths.push(absolute);
 		}
 	}
 	return paths;
@@ -76,19 +509,9 @@ function extract_redirect_create_paths(
 	command: string,
 	cwd: string,
 ): string[] {
-	const paths: string[] = [];
-	const pattern =
-		/(?:^|\s)(?:[12]>>|>>|&>|[12]?>)(?:\s*)("[^"]+"|'[^']+'|\S+)/g;
-	let match: RegExpExecArray | null;
-	while ((match = pattern.exec(command))) {
-		const raw = match[1];
-		const path = raw.replace(/^(['"])(.*)\1$/, '$2');
-		const absolute = resolve(cwd, path);
-		if (is_temp_path(absolute) && !existsSync(absolute)) {
-			paths.push(absolute);
-		}
-	}
-	return paths;
+	return extract_overwrite_paths(command)
+		.map((path) => resolve(cwd, path))
+		.filter((path) => is_temp_path(path) && !existsSync(path));
 }
 
 export function extract_bash_create_paths(
@@ -104,15 +527,16 @@ export function extract_bash_create_paths(
 export function command_may_create_temp_path(
 	command: string,
 ): boolean {
-	return /^\s*mktemp\b/.test(command);
+	return extract_shell_invocations(command).some(
+		(invocation) => invocation.command === 'mktemp',
+	);
 }
 
 function text_content(event: ToolResultEvent): string {
 	return event.content
 		.map((part) => {
-			if ('text' in part && typeof part.text === 'string') {
+			if ('text' in part && typeof part.text === 'string')
 				return part.text;
-			}
 			return '';
 		})
 		.join('');

--- a/packages/pi-confirm-destructive/src/destructive/types.ts
+++ b/packages/pi-confirm-destructive/src/destructive/types.ts
@@ -15,4 +15,6 @@ export type GitRecoverability =
 	| 'tracked-clean'
 	| 'tracked-dirty'
 	| 'untracked'
+	| 'ignored'
+	| 'repo-root'
 	| 'not-git';

--- a/packages/pi-confirm-destructive/src/index.test.ts
+++ b/packages/pi-confirm-destructive/src/index.test.ts
@@ -83,6 +83,7 @@ describe('assess_bash_command', () => {
 		'sqlite3 app.db "delete from users"',
 		'find . -name "*.tmp" -delete',
 		'git clean -fdx',
+		'git -C . clean -fdx',
 		'rsync -a --delete src/ dest/',
 		'truncate -s 0 app.log',
 	])('detects broadly destructive command: %s', (command) => {
@@ -173,6 +174,85 @@ describe('assess_bash_command', () => {
 		expect(assess_bash_command(command)?.reason).toBe(
 			'Overwrites remote git history',
 		);
+	});
+
+	it.each([
+		'echo ready\nrm -rf untracked.md',
+		'echo x | xargs rm -rf untracked.md',
+		"sh -c 'rm -rf untracked.md'",
+		'(rm -rf untracked.md)',
+		'{ rm -rf untracked.md; }',
+		'env rm -rf untracked.md',
+		'command rm -rf untracked.md',
+		'find . -execdir rm -rf untracked.md \\;',
+		"find . -execdir sh -c 'rm -rf untracked.md' \\;",
+		"echo x | xargs sh -c 'rm -rf untracked.md'",
+		'echo "$(rm -rf untracked.md)"',
+		'echo `rm -rf untracked.md`',
+		"eval 'rm -rf untracked.md'",
+		"sudo --user root env FLAG=1 bash -lc 'rm -rf untracked.md'",
+	])('detects wrapped or compound removal: %s', (command) => {
+		const cwd = create_git_repo();
+		writeFileSync(join(cwd, 'untracked.md'), 'important');
+		expect(assess_bash_command(command, cwd)).toBeTruthy();
+	});
+
+	it('does not confuse quoted destructive-looking text with command intent', () => {
+		expect(
+			assess_bash_command("printf '%s\\n' 'rm -rf important.md'"),
+		).toBeUndefined();
+	});
+
+	it('preserves safe git and redirect operations', () => {
+		const cwd = create_git_repo();
+		expect(
+			assess_bash_command('git branch -d merged', cwd),
+		).toBeUndefined();
+		expect(
+			assess_bash_command('echo replacement > tracked.md', cwd),
+		).toBeUndefined();
+		expect(
+			assess_bash_command('echo ok > /dev/null', cwd),
+		).toBeUndefined();
+		expect(
+			assess_bash_command('find . -exec printf "%s\\n" {} \\;', cwd),
+		).toBeUndefined();
+	});
+
+	it('treats the repository root as unrecoverable', () => {
+		const cwd = create_git_repo();
+		expect(assess_bash_command('rm -rf .', cwd)).toBeTruthy();
+	});
+
+	it('treats ignored files beneath a tracked directory as unrecoverable', () => {
+		const cwd = create_git_repo();
+		mkdirSync(join(cwd, 'src'));
+		writeFileSync(join(cwd, 'src', 'tracked.ts'), 'tracked');
+		writeFileSync(join(cwd, '.gitignore'), 'src/.env\n');
+		git(cwd, ['add', 'src/tracked.ts', '.gitignore']);
+		git(cwd, ['commit', '-m', 'add src']);
+		writeFileSync(join(cwd, 'src', '.env'), 'important');
+
+		expect(assess_bash_command('rm -rf src', cwd)).toBeTruthy();
+	});
+
+	it.each([
+		'> untracked.log',
+		': > untracked.log',
+		"sed -i 's/old/new/' untracked.log",
+		'git stash drop',
+		'git branch -D old-branch',
+		'git push origin --delete old-branch',
+		'docker system prune -af',
+		'dropdb production',
+		'redis-cli flushall',
+		'terraform destroy -auto-approve',
+		'aws s3 rm s3://bucket --recursive',
+		'kubectl delete namespace production',
+	])('detects destructive command family: %s', (command) => {
+		const cwd = create_git_repo();
+		writeFileSync(join(cwd, 'untracked.log'), 'important');
+		expect(assess_bash_command(command, cwd)).toBeTruthy();
 	});
 });
 

--- a/packages/pi-confirm-destructive/src/index.test.ts
+++ b/packages/pi-confirm-destructive/src/index.test.ts
@@ -83,6 +83,7 @@ describe('assess_bash_command', () => {
 		'sqlite3 app.db "delete from users"',
 		'find . -name "*.tmp" -delete',
 		'git clean -fdx',
+		'git clean --force -d',
 		'git -C . clean -fdx',
 		'rsync -a --delete src/ dest/',
 		'truncate -s 0 app.log',
@@ -191,6 +192,11 @@ describe('assess_bash_command', () => {
 		'echo `rm -rf untracked.md`',
 		"eval 'rm -rf untracked.md'",
 		"sudo --user root env FLAG=1 bash -lc 'rm -rf untracked.md'",
+		'nice -n 5 rm -rf untracked.md',
+		'ionice -c 3 rm -rf untracked.md',
+		'stdbuf -o L rm -rf untracked.md',
+		'setsid rm -rf untracked.md',
+		'busybox rm -rf untracked.md',
 	])('detects wrapped or compound removal: %s', (command) => {
 		const cwd = create_git_repo();
 		writeFileSync(join(cwd, 'untracked.md'), 'important');
@@ -201,6 +207,25 @@ describe('assess_bash_command', () => {
 		expect(
 			assess_bash_command("printf '%s\\n' 'rm -rf important.md'"),
 		).toBeUndefined();
+	});
+
+	it('does not treat heredoc bodies as executable command intent', () => {
+		const command = [
+			"cat > guide.md <<'EOF'",
+			'rm -rf is dangerous documentation',
+			'EOF',
+		].join('\n');
+		expect(assess_bash_command(command)).toBeUndefined();
+	});
+
+	it('still detects destructive commands following a heredoc', () => {
+		const command = [
+			"cat > guide.md <<'EOF'",
+			'rm -rf is dangerous documentation',
+			'EOF',
+			'rm -rf untracked.md',
+		].join('\n');
+		expect(assess_bash_command(command)).toBeTruthy();
 	});
 
 	it('preserves safe git and redirect operations', () => {
@@ -240,9 +265,13 @@ describe('assess_bash_command', () => {
 		'> untracked.log',
 		': > untracked.log',
 		"sed -i 's/old/new/' untracked.log",
+		"sed --in-place 's/old/new/' untracked.log",
 		'git stash drop',
 		'git branch -D old-branch',
+		'git branch --delete --force old-branch',
 		'git push origin --delete old-branch',
+		'git push -d origin old-branch',
+		'git push origin :old-branch',
 		'docker system prune -af',
 		'dropdb production',
 		'redis-cli flushall',

--- a/packages/pi-redact/README.md
+++ b/packages/pi-redact/README.md
@@ -36,11 +36,15 @@ output, file reads, logs, and config files.
 
 It currently detects and redacts:
 
-- API-key-like fields such as `password`, `secret`, `token`, and
-  `api_key`
-- GitHub classic and fine-grained tokens
-- Tavily, Kagi, Brave, and Firecrawl API keys
-- connection strings with embedded credentials
+- quoted JSON and unquoted environment/config fields with sensitive
+  names such as `password`, `client_secret`, `access_token`, and
+  `api_key`, including values containing shell punctuation
+- GitHub, GitLab, Slack, npm, Google, SendGrid, JWT, and common
+  vendor-prefixed tokens
+- AWS credentials, bearer tokens, and connection strings with embedded
+  credentials
+- private-key blocks and partial private-key reads; sequential `read`
+  chunks for the same path remain redacted after a private-key header
 - SSH config metadata such as `Host`, `HostName`, `User`,
   `IdentityFile`, `ProxyJump`, and forwarding directives
 
@@ -85,11 +89,18 @@ import redact from '@spences10/pi-redact';
 ## Limitations
 
 This extension is defensive, not a guarantee. It can miss novel secret
-formats, and broad patterns can occasionally redact benign values. Use
-proper secret hygiene as the primary control:
+formats, dynamically assembled values, and chunks that begin midway
+through a secret without prior context. It intentionally does not
+blanket-redact unlabelled base64, compressed, encrypted, or other
+high-entropy output because source archives, hashes, and build
+artifacts commonly have the same shape. Broad patterns can also
+occasionally redact benign values.
 
-- do not print secrets unnecessarily
-- avoid reading `.env` files into model context
+Use proper secret hygiene as the primary control:
+
+- do not print or encode secrets unnecessarily
+- avoid reading `.env` files into model context; prefer `nopeek` for
+  secret-safe environment loading
 - prefer scoped, revocable tokens
 - rotate anything that may have been exposed
 

--- a/packages/pi-redact/src/index.test.ts
+++ b/packages/pi-redact/src/index.test.ts
@@ -192,6 +192,71 @@ describe('redact_text', () => {
 		);
 	});
 
+	it('redacts private-key continuations split across text content blocks', async () => {
+		let tool_result_handler:
+			| ((event: Record<string, unknown>) => unknown)
+			| undefined;
+		const pi = {
+			on(
+				name: string,
+				handler: (event: Record<string, unknown>) => unknown,
+			) {
+				if (name === 'tool_result') tool_result_handler = handler;
+			},
+			registerCommand() {},
+		};
+		await filter_output(pi as never);
+		const continuation = 'Q0FOQVJZX1BSSVZBVEVfQk9EWV9DT05URU5U';
+		const result = (await tool_result_handler?.({
+			toolName: 'read',
+			input: { path: '/tmp/split-content-key.pem' },
+			content: [
+				{ type: 'text', text: `-----${'BEGIN PRIVATE KEY-----'}\n` },
+				{ type: 'text', text: continuation },
+			],
+		})) as { content?: Array<{ text?: string }> };
+
+		expect(result.content?.[1]?.text).toContain(
+			'[REDACTED:Private Key continuation]',
+		);
+		expect(result.content?.[1]?.text).not.toContain(continuation);
+	});
+
+	it('normalizes read paths before tracking private-key continuations', async () => {
+		let tool_result_handler:
+			| ((event: Record<string, unknown>) => unknown)
+			| undefined;
+		const pi = {
+			on(
+				name: string,
+				handler: (event: Record<string, unknown>) => unknown,
+			) {
+				if (name === 'tool_result') tool_result_handler = handler;
+			},
+			registerCommand() {},
+		};
+		await filter_output(pi as never);
+		const continuation =
+			'Q0FOQVJZX1NFQ09ORF9DSFVOS19QUklWQVRFX0tFWQ==';
+		await tool_result_handler?.({
+			toolName: 'read',
+			input: { path: '/tmp/equivalent-key.pem' },
+			content: [
+				{ type: 'text', text: `-----${'BEGIN PRIVATE KEY-----'}\n` },
+			],
+		});
+		const result = (await tool_result_handler?.({
+			toolName: 'read',
+			input: { path: '/tmp/./equivalent-key.pem', offset: 2 },
+			content: [{ type: 'text', text: continuation }],
+		})) as { content?: Array<{ text?: string }> };
+
+		expect(result.content?.[0]?.text).toContain(
+			'[REDACTED:Private Key continuation]',
+		);
+		expect(result.content?.[0]?.text).not.toContain(continuation);
+	});
+
 	it('redacts GitHub fine-grained PATs', () => {
 		const input = 'github_pat_' + 'A'.repeat(30);
 		const { redacted, count } = redact_text(input);

--- a/packages/pi-redact/src/index.test.ts
+++ b/packages/pi-redact/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
+import filter_output, {
 	looks_like_ssh_config,
 	redact_ssh_config_metadata,
 	redact_text,
@@ -71,6 +71,125 @@ describe('redact_text', () => {
 		expect(count).toBe(1);
 		expect(redacted).toContain('[REDACTED:Generic Password Field]');
 		expect(redacted).not.toContain('CanaryPassword-Redaction-001!');
+	});
+
+	it('redacts quoted JSON secret fields without leaking their values', () => {
+		const values = {
+			password: ['super', 'secret', '12345'].join(''),
+			access_token: ['opaque', '-token-', 'value!'].join(''),
+			client_secret: ['client', '$#%&*?', 'secret'].join(''),
+			refresh_token: ['refresh', '-opaque-', 'credential'].join(''),
+			aws_secret_access_key: ['A1b2', '/+=', 'C3d4']
+				.join('')
+				.repeat(5),
+		};
+		const input = JSON.stringify(values);
+		const { redacted, count } = redact_text(input);
+
+		expect(count).toBe(5);
+		for (const value of Object.values(values)) {
+			expect(redacted).not.toContain(value);
+		}
+		expect(redacted).toContain('[REDACTED:Generic Password Field]');
+	});
+
+	it('redacts the complete value when an env secret contains shell punctuation', () => {
+		const value = ['p@', '$$', 'w0rd!', 'xyz#%&*?~^'].join('');
+		const input = `PASSWORD=${value}`;
+		const { redacted, count } = redact_text(input);
+
+		expect(count).toBe(1);
+		expect(redacted).not.toContain(value);
+		expect(redacted).not.toContain('xyz#%&*?~^');
+	});
+
+	it.each([
+		[
+			'JWT',
+			[
+				'eyJ',
+				'hbGciOiJIUzI1NiJ9',
+				'.',
+				'eyJzdWIiOiIxMjM0NTY3ODkwIn0',
+				'.',
+				'signaturevalue123456',
+			].join(''),
+		],
+		['Slack Token', `xoxb-${'A'.repeat(32)}`],
+		['GitLab Token', `glpat-${'B'.repeat(24)}`],
+		['Google API Key', `AIza${'C'.repeat(35)}`],
+		['npm Token', `npm_${'D'.repeat(36)}`],
+		['SendGrid API Key', `SG.${'E'.repeat(24)}.${'F'.repeat(43)}`],
+	])('redacts %s credentials', (_name, credential) => {
+		const { redacted, count } = redact_text(credential);
+		expect(count).toBe(1);
+		expect(redacted).not.toContain(credential);
+	});
+
+	it('redacts a private-key chunk even when its END marker is absent', () => {
+		const private_key_chunk = [
+			'-----BEGIN PRIVATE KEY-----',
+			'Q0FOQVJZX1BSSVZBVEVfS0VZX0ZJUlNUX0NIVU5L',
+		].join('\n');
+		const { redacted, count } = redact_text(private_key_chunk);
+
+		expect(count).toBe(1);
+		expect(redacted).not.toContain(
+			'Q0FOQVJZX1BSSVZBVEVfS0VZX0ZJUlNUX0NIVU5L',
+		);
+		expect(redacted).toContain('[REDACTED:Private Key]');
+	});
+
+	it('does not blanket-redact unlabelled encoded output', () => {
+		const input = Buffer.from(
+			'ordinary build artifact content without credentials',
+		).toString('base64');
+		const { redacted, count } = redact_text(input);
+		expect(count).toBe(0);
+		expect(redacted).toBe(input);
+	});
+
+	it('tracks and redacts private-key continuations across read chunks', async () => {
+		let tool_result_handler:
+			| ((event: Record<string, unknown>) => unknown)
+			| undefined;
+		const pi = {
+			on(
+				name: string,
+				handler: (event: Record<string, unknown>) => unknown,
+			) {
+				if (name === 'tool_result') tool_result_handler = handler;
+			},
+			registerCommand() {},
+		};
+		await filter_output(pi as never);
+		const path = '/tmp/chunked-private-key.pem';
+		const first_chunk = [
+			'-----BEGIN PRIVATE KEY-----',
+			'Q0FOQVJZX0ZJUlNUX0NIVU5LX1BSSVZBVEVfS0VZ',
+		].join('\n');
+		const second_chunk = [
+			'Q0FOQVJZX1NFQ09ORF9DSFVOS19QUklWQVRFX0tFWQ==',
+			'-----END PRIVATE KEY-----',
+		].join('\n');
+
+		await tool_result_handler?.({
+			toolName: 'read',
+			input: { path },
+			content: [{ type: 'text', text: first_chunk }],
+		});
+		const result = (await tool_result_handler?.({
+			toolName: 'read',
+			input: { path, offset: 2 },
+			content: [{ type: 'text', text: second_chunk }],
+		})) as { content?: Array<{ text?: string }> };
+
+		expect(result.content?.[0]?.text).toContain(
+			'[REDACTED:Private Key continuation]',
+		);
+		expect(result.content?.[0]?.text).not.toContain(
+			'Q0FOQVJZX1NFQ09ORF9DSFVOS19QUklWQVRFX0tFWQ==',
+		);
 	});
 
 	it('redacts GitHub fine-grained PATs', () => {

--- a/packages/pi-redact/src/index.ts
+++ b/packages/pi-redact/src/index.ts
@@ -17,6 +17,16 @@ interface RedactionResult {
 	count: number;
 }
 
+interface RedactionOptions {
+	force_ssh_config?: boolean;
+	force_private_key?: boolean;
+}
+
+const PRIVATE_KEY_BEGIN_PATTERN =
+	/-----BEGIN[ \t]+[\w -]*PRIVATE[ \t]+KEY-----/;
+const PRIVATE_KEY_END_PATTERN =
+	/-----END[ \t]+[\w -]*PRIVATE[ \t]+KEY-----/;
+
 const SECRET_PATTERNS: SecretPattern[] = [
 	{ name: 'AWS Access Key', pattern: /AKIA[A-Z0-9]{16}/g },
 	{ name: 'AWS Temp Access Key', pattern: /ASIA[A-Z0-9]{16}/g },
@@ -49,16 +59,11 @@ const SECRET_PATTERNS: SecretPattern[] = [
 	{
 		name: 'Private Key',
 		pattern:
-			/-----BEGIN\s+[\w\s]*PRIVATE\s+KEY-----[\s\S]*?-----END\s+[\w\s]*PRIVATE\s+KEY-----/g,
+			/-----BEGIN[ \t]+[\w -]*PRIVATE[ \t]+KEY-----[\s\S]*?(?:-----END[ \t]+[\w -]*PRIVATE[ \t]+KEY-----|$)/g,
 	},
 	{
 		name: 'Connection String with Password',
 		pattern: /\b[a-z][a-z0-9+.-]*:\/\/[^:\s/?#]+:[^@\s/?#]+@/gi,
-	},
-	{
-		name: 'Generic Password Field',
-		pattern:
-			/\b(?:[A-Z0-9_]*(?:PASSWORD|PASSWD|SECRET|TOKEN|API_?KEY)|password|passwd|secret|token|api[_-]?key)\b[ \t]*[:=][ \t]*["']?[A-Za-z0-9._:/+=@!-]{8,}["']?/g,
 	},
 	{
 		name: 'Generic Secret Phrase',
@@ -89,7 +94,57 @@ const SECRET_PATTERNS: SecretPattern[] = [
 		name: 'GitHub Fine-grained PAT',
 		pattern: /github_pat_[a-zA-Z0-9_]{20,}/g,
 	},
+	{
+		name: 'JWT',
+		pattern:
+			/eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g,
+	},
+	{
+		name: 'Slack Token',
+		pattern: /xox[baprs]-[A-Za-z0-9-]{20,}/g,
+	},
+	{
+		name: 'GitLab Token',
+		pattern: /glpat-[A-Za-z0-9_-]{20,}/g,
+	},
+	{
+		name: 'Google API Key',
+		pattern: /AIza[A-Za-z0-9_-]{35}/g,
+	},
+	{
+		name: 'npm Token',
+		pattern: /npm_[A-Za-z0-9]{36,}/g,
+	},
+	{
+		name: 'SendGrid API Key',
+		pattern: /SG\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{32,}/g,
+	},
 ];
+
+const SECRET_FIELD_NAME =
+	'(?:[A-Z0-9_]*(?:PASSWORD|PASSWD|SECRET|TOKEN|API_?KEY)|password|passwd|secret|token|api[_-]?key|access[_-]?token|client[_-]?secret|private[_-]?key)';
+const JSON_SECRET_FIELD_NAME =
+	'[A-Za-z0-9_-]*(?:password|passwd|secret|token|api[_-]?key|access[_-]?key|private[_-]?key)';
+const DOUBLE_QUOTED_JSON_SECRET_FIELD_PATTERN = new RegExp(
+	`(^|[^A-Za-z0-9_])((?:"${JSON_SECRET_FIELD_NAME}")[ \\t]*:[ \\t]*")((?:\\\\.|[^"\\\\]){8,})"`,
+	'gim',
+);
+const SINGLE_QUOTED_JSON_SECRET_FIELD_PATTERN = new RegExp(
+	`(^|[^A-Za-z0-9_])((?:'${JSON_SECRET_FIELD_NAME}')[ \\t]*:[ \\t]*')((?:\\\\.|[^'\\\\]){8,})'`,
+	'gim',
+);
+const DOUBLE_QUOTED_SECRET_FIELD_PATTERN = new RegExp(
+	`(^|[^A-Za-z0-9_])((?:"?${SECRET_FIELD_NAME}"?)[ \\t]*[:=][ \\t]*")((?:\\\\.|[^"\\\\]){8,})"`,
+	'gm',
+);
+const SINGLE_QUOTED_SECRET_FIELD_PATTERN = new RegExp(
+	`(^|[^A-Za-z0-9_])((?:'?${SECRET_FIELD_NAME}'?)[ \\t]*[:=][ \\t]*')((?:\\\\.|[^'\\\\]){8,})'`,
+	'gm',
+);
+const UNQUOTED_SECRET_FIELD_PATTERN = new RegExp(
+	`(^|[^A-Za-z0-9_])((?:${SECRET_FIELD_NAME})[ \\t]*[:=][ \\t]*)([^\\s"',;}\\]]{8,})`,
+	'gm',
+);
 
 const SSH_CONFIG_VALUE_DIRECTIVE_PATTERN =
 	/^([ \t]*)(HostName|User|IdentityFile|CertificateFile|ProxyJump|ProxyCommand|LocalForward|RemoteForward|DynamicForward|HostKeyAlias)(\s+)(.+)$/gim;
@@ -164,6 +219,45 @@ export function redact_ssh_config_metadata(
 	return { redacted: result, count };
 }
 
+function redact_secret_fields(text: string): RedactionResult {
+	let count = 0;
+	let result = text;
+	const marker = '[REDACTED:Generic Password Field]';
+
+	const redact_quoted = (pattern: RegExp, quote: '"' | "'"): void => {
+		pattern.lastIndex = 0;
+		result = result.replace(
+			pattern,
+			(
+				match,
+				boundary: string,
+				assignment: string,
+				value: string,
+			) => {
+				if (value.includes('[REDACTED:')) return match;
+				count += 1;
+				return `${boundary}${assignment}${marker}${quote}`;
+			},
+		);
+	};
+
+	redact_quoted(DOUBLE_QUOTED_JSON_SECRET_FIELD_PATTERN, '"');
+	redact_quoted(SINGLE_QUOTED_JSON_SECRET_FIELD_PATTERN, "'");
+	redact_quoted(DOUBLE_QUOTED_SECRET_FIELD_PATTERN, '"');
+	redact_quoted(SINGLE_QUOTED_SECRET_FIELD_PATTERN, "'");
+	UNQUOTED_SECRET_FIELD_PATTERN.lastIndex = 0;
+	result = result.replace(
+		UNQUOTED_SECRET_FIELD_PATTERN,
+		(match, boundary: string, assignment: string, value: string) => {
+			if (value.includes('[REDACTED:')) return match;
+			count += 1;
+			return `${boundary}${assignment}${marker}`;
+		},
+	);
+
+	return { redacted: result, count };
+}
+
 function redact_secret_patterns(text: string): RedactionResult {
 	let count = 0;
 	let result = text;
@@ -205,8 +299,15 @@ function is_text_content(
 
 export function redact_text(
 	text: string,
-	options?: { force_ssh_config?: boolean },
+	options?: RedactionOptions,
 ): RedactionResult {
+	if (options?.force_private_key && text) {
+		return {
+			redacted: '[REDACTED:Private Key continuation]',
+			count: 1,
+		};
+	}
+
 	let count = 0;
 	let result = text;
 
@@ -216,6 +317,10 @@ export function redact_text(
 		count += ssh_redaction.count;
 	}
 
+	const field_redaction = redact_secret_fields(result);
+	result = field_redaction.redacted;
+	count += field_redaction.count;
+
 	const secret_redaction = redact_secret_patterns(result);
 	result = secret_redaction.redacted;
 	count += secret_redaction.count;
@@ -224,36 +329,62 @@ export function redact_text(
 }
 
 export default async function filter_output(pi: ExtensionAPI) {
-	let totalRedacted = 0;
+	let total_redacted = 0;
+	const partial_private_key_paths = new Set<string>();
 
 	pi.on('tool_result', async (event) => {
 		if (!event.content) return;
 
 		const force_ssh_config = should_force_ssh_config_redaction(event);
+		const input_path =
+			event.toolName === 'read' &&
+			event.input &&
+			typeof event.input === 'object' &&
+			typeof (event.input as { path?: unknown }).path === 'string'
+				? (event.input as { path: string }).path
+				: undefined;
+		const text = event.content
+			.filter(is_text_content)
+			.map((item) => item.text)
+			.join('');
+		const force_private_key = Boolean(
+			input_path && partial_private_key_paths.has(input_path),
+		);
 		let modified = false;
 
-		const newContent = event.content.map((item) => {
+		const new_content = event.content.map((item) => {
 			if (!is_text_content(item) || !item.text) return item;
 			const { redacted, count } = redact_text(item.text, {
 				force_ssh_config,
+				force_private_key,
 			});
 			if (count > 0) {
 				modified = true;
-				totalRedacted += count;
+				total_redacted += count;
 			}
 			return { ...item, text: redacted } satisfies TextContent;
 		});
 
-		if (modified) {
-			return { content: newContent };
+		if (input_path) {
+			if (force_private_key && PRIVATE_KEY_END_PATTERN.test(text)) {
+				partial_private_key_paths.delete(input_path);
+			}
+			if (
+				PRIVATE_KEY_BEGIN_PATTERN.test(text) &&
+				!PRIVATE_KEY_END_PATTERN.test(text)
+			) {
+				partial_private_key_paths.add(input_path);
+			}
 		}
+
+		if (modified) return { content: new_content };
 	});
 
 	pi.registerCommand('redact-stats', {
 		description: 'Show how many secrets have been redacted',
 		handler: async (_args, ctx) => {
 			ctx.ui.notify(
-				`Secrets redacted this session: ${totalRedacted}`,
+				`Secrets redacted this session: ${total_redacted}`,
 			);
 		},
 	});

--- a/packages/pi-redact/src/index.ts
+++ b/packages/pi-redact/src/index.ts
@@ -6,6 +6,7 @@ import type {
 	TextContent,
 } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { resolve } from 'node:path';
 
 interface SecretPattern {
 	name: string;
@@ -343,12 +344,12 @@ export default async function filter_output(pi: ExtensionAPI) {
 			typeof (event.input as { path?: unknown }).path === 'string'
 				? (event.input as { path: string }).path
 				: undefined;
-		const text = event.content
-			.filter(is_text_content)
-			.map((item) => item.text)
-			.join('');
-		const force_private_key = Boolean(
-			input_path && partial_private_key_paths.has(input_path),
+		const normalized_input_path = input_path
+			? resolve(input_path)
+			: undefined;
+		let private_key_continuation = Boolean(
+			normalized_input_path &&
+			partial_private_key_paths.has(normalized_input_path),
 		);
 		let modified = false;
 
@@ -356,24 +357,34 @@ export default async function filter_output(pi: ExtensionAPI) {
 			if (!is_text_content(item) || !item.text) return item;
 			const { redacted, count } = redact_text(item.text, {
 				force_ssh_config,
-				force_private_key,
+				force_private_key: private_key_continuation,
 			});
 			if (count > 0) {
 				modified = true;
 				total_redacted += count;
 			}
+
+			const has_private_key_begin = PRIVATE_KEY_BEGIN_PATTERN.test(
+				item.text,
+			);
+			const has_private_key_end = PRIVATE_KEY_END_PATTERN.test(
+				item.text,
+			);
+			if (private_key_continuation && has_private_key_end) {
+				private_key_continuation = false;
+			}
+			if (has_private_key_begin) {
+				private_key_continuation = !has_private_key_end;
+			}
+
 			return { ...item, text: redacted } satisfies TextContent;
 		});
 
-		if (input_path) {
-			if (force_private_key && PRIVATE_KEY_END_PATTERN.test(text)) {
-				partial_private_key_paths.delete(input_path);
-			}
-			if (
-				PRIVATE_KEY_BEGIN_PATTERN.test(text) &&
-				!PRIVATE_KEY_END_PATTERN.test(text)
-			) {
-				partial_private_key_paths.add(input_path);
+		if (normalized_input_path) {
+			if (private_key_continuation) {
+				partial_private_key_paths.add(normalized_input_path);
+			} else {
+				partial_private_key_paths.delete(normalized_input_path);
 			}
 		}
 


### PR DESCRIPTION
## Summary

- harden `pi-redact` handling for JSON-quoted secrets, broader secret shapes, and partial-redaction leaks
- harden `pi-confirm-destructive` parsing across multiline commands, wrappers, pipelines, subshells, and destructive command variants
- treat repository roots and ignored/unrecoverable content conservatively
- add regression coverage and update package documentation

## Validation

- 32 `pi-redact` tests
- 72 `pi-confirm-destructive` tests
- package type checks
- root `pnpm run check`
- harness guard and final diff checks

LSP diagnostics were attempted on the remote worker, but `typescript-language-server` was unavailable there.

## Remaining limits

Unlabelled encoded secrets and dynamically constructed or novel shell commands cannot be guaranteed detectable without blanket blocking.

Closes #372
