### PR TITLE
fix: harden trust boundaries and publishing provenance

### DIFF
--- a/.changeset/trusted-boundaries.md
+++ b/.changeset/trusted-boundaries.md
@@ -1,0 +1,7 @@
+---
+'@spences10/pi-mcp': patch
+'@spences10/pi-observability': patch
+---
+
+Harden MCP policy boundaries and observability authentication while
+adding trusted publishing provenance for package releases.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish packages
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: npm
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check
+        run: pnpm run check
+
+      - name: Test
+        run: pnpm run test
+
+      - name: Publish with npm trusted publishing
+        run: pnpm run release
+        env:
+          NPM_CONFIG_PROVENANCE: 'true'

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ Shared helper packages such as `@spences10/pi-child-env`,
 `@spences10/pi-tui-modal` are published as dependencies and are not
 packages to install via `pi install`.
 
+Maintainers publish from GitHub Actions with npm trusted publishing;
+see [`docs/releases.md`](./docs/releases.md) for the workflow and the
+required owner-side configuration.
+
 ## Project structure
 
 ```text

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,49 @@
+# Package releases
+
+The supported package-publishing path runs from the GitHub-hosted
+workflow in `.github/workflows/publish.yml`. The workflow is manually
+dispatched from `main`, validates the repository, and grants only
+`contents: read` plus `id-token: write`. npm trusted publishing
+exchanges that GitHub OIDC identity for a short-lived publish
+credential; no npm token is stored in GitHub.
+`NPM_CONFIG_PROVENANCE=true` also makes provenance explicit for the
+third-party monorepo publisher. npm currently generates provenance
+attestations automatically for public packages published from a public
+GitHub repository through trusted publishing.
+
+Versioning remains separate: prepare and merge the normal version
+update before dispatching the workflow. The workflow publishes only
+package versions that are not already present in npm. Never dispatch
+it from a feature branch.
+
+## Required owner setup
+
+Repository code cannot configure npm package ownership or GitHub
+deployment protection. Before the first workflow run, an owner must
+complete all of the following:
+
+1. Create a GitHub environment named `npm`, restrict it to `main`, and
+   add any desired reviewer protection.
+2. For `my-pi` and every published `@spences10/pi-*` package,
+   configure npm trusted publishing with:
+   - provider: GitHub Actions
+   - organization or user: `spences10`
+   - repository: `my-pi`
+   - workflow filename: `publish.yml`
+   - environment: `npm`
+   - allowed action: `npm publish`
+3. Dispatch **Publish packages** from `main` after the version update
+   has landed.
+4. Confirm each published package exposes an npm provenance
+   attestation. After one successful OIDC release, disallow token
+   publishing where practical and revoke obsolete long-lived
+   automation tokens.
+
+Trusted publishing requires npm CLI 11.5.1 or newer, Node.js 22.14 or
+newer, and a GitHub-hosted runner. The workflow uses Node.js 24. If
+any package is missing the npm-side trusted-publisher mapping, the
+workflow must fail rather than fall back to a repository npm token.
+
+`minimumReleaseAge` and its `pirecall` exception affect dependency
+installation freshness, not package publication identity. They are not
+a substitute for—or part of—OIDC trusted publishing and provenance.

--- a/packages/pi-mcp/README.md
+++ b/packages/pi-mcp/README.md
@@ -68,10 +68,13 @@ and discover tools eagerly.
 Keep `mcp.json` portable by putting my-pi activation rules in a
 separate policy file. Global policy lives at
 `~/.pi/agent/mcp-policy.json`; project policy lives at
-`.pi/mcp-policy.json` and overrides global entries by server name. A
-server with no policy keeps the default behavior. A server with an
-`activateWhen` policy is skipped entirely unless at least one
-criterion matches the current cwd or GitHub remote.
+`.pi/mcp-policy.json`. Project policy is loaded only when project MCP
+config passes the project trust decision. It may further restrict a
+global policy, but cannot replace or widen one; when both scopes
+define a server, both policies must match. A server with no policy
+keeps the default behavior. A server with an `activateWhen` policy is
+skipped entirely unless at least one criterion matches the current cwd
+or GitHub remote.
 
 ```json
 {

--- a/packages/pi-mcp/src/config.test.ts
+++ b/packages/pi-mcp/src/config.test.ts
@@ -491,7 +491,7 @@ describe('load_mcp_config', () => {
 		);
 	});
 
-	it('lets project MCP policy override global policy', () => {
+	it('does not let project MCP policy widen global activation', () => {
 		const home = tmp_dir();
 		const cwd = tmp_dir();
 		dirs.push(home, cwd);
@@ -518,16 +518,50 @@ describe('load_mcp_config', () => {
 		});
 		writeFileSync(
 			join(cwd, '.pi', 'mcp-policy.json'),
+			JSON.stringify({ servers: { scoped: {} } }),
+		);
+
+		expect(load_mcp_config(cwd)).toEqual([]);
+	});
+
+	it('lets project MCP policy further restrict global activation', () => {
+		const home = tmp_dir();
+		const cwd = tmp_dir();
+		dirs.push(home, cwd);
+		process.env.HOME = home;
+
+		const global_dir = join(home, '.pi', 'agent');
+		mkdirSync(global_dir, { recursive: true });
+		mkdirSync(join(cwd, '.pi'), { recursive: true });
+		writeFileSync(
+			join(global_dir, 'mcp.json'),
+			JSON.stringify({ mcpServers: { scoped: { command: 'cmd' } } }),
+		);
+		write_settings({
+			version: 1,
+			mcp: {
+				policy: {
+					servers: {
+						scoped: { activateWhen: { cwdPrefix: cwd } },
+					},
+				},
+			},
+		});
+		writeFileSync(
+			join(cwd, '.pi', 'mcp-policy.json'),
 			JSON.stringify({
 				servers: {
-					scoped: { activateWhen: { cwdPrefix: cwd } },
+					scoped: {
+						activateWhen: { githubRepo: ['elsewhere/project'] },
+					},
 				},
 			}),
 		);
 
-		expect(load_mcp_config(cwd).map((config) => config.name)).toEqual(
-			['scoped'],
-		);
+		expect(load_mcp_config(cwd)).toEqual([]);
+		expect(load_mcp_config(cwd, { include_project: false })).toEqual([
+			{ name: 'scoped', transport: 'stdio', command: 'cmd' },
+		]);
 	});
 
 	it('lets project config override global config by name', () => {

--- a/packages/pi-mcp/src/config.ts
+++ b/packages/pi-mcp/src/config.ts
@@ -81,12 +81,17 @@ export function load_mcp_config(
 		...Object.keys(project_servers),
 	]);
 
-	const policies = load_mcp_policy(cwd);
+	const policies = load_mcp_policy(
+		cwd,
+		options.include_project !== false,
+	);
 	const github_repos = get_github_repos(cwd);
 
 	return Array.from(merged_names)
 		.filter((name) =>
-			policy_matches(policies[name], cwd, github_repos),
+			(policies[name] ?? []).every((policy) =>
+				policy_matches(policy, cwd, github_repos),
+			),
 		)
 		.map((name) => {
 			const project_server = project_servers[name];

--- a/packages/pi-mcp/src/config/policy.ts
+++ b/packages/pi-mcp/src/config/policy.ts
@@ -71,11 +71,29 @@ export function get_github_repos(cwd: string): string[] {
 
 export function load_mcp_policy(
 	cwd: string,
-): Record<string, RawMcpPolicyEntry> {
-	return {
-		...read_policy_file(global_mcp_policy_path()).servers,
-		...read_policy_file(project_mcp_policy_path(cwd)).servers,
-	};
+	include_project = true,
+): Record<string, RawMcpPolicyEntry[]> {
+	const global =
+		read_policy_file(global_mcp_policy_path()).servers ?? {};
+	const project = include_project
+		? (read_policy_file(project_mcp_policy_path(cwd)).servers ?? {})
+		: {};
+	const names = new Set([
+		...Object.keys(global),
+		...Object.keys(project),
+	]);
+	return Object.fromEntries(
+		Array.from(
+			names,
+			(name) =>
+				[
+					name,
+					[global[name], project[name]].filter(
+						(policy): policy is RawMcpPolicyEntry => Boolean(policy),
+					),
+				] as const,
+		),
+	);
 }
 
 export function policy_matches(

--- a/packages/pi-observability/README.md
+++ b/packages/pi-observability/README.md
@@ -56,6 +56,7 @@ Server environment variables:
 MY_PI_OBSERVABILITY_HOST=127.0.0.1
 MY_PI_OBSERVABILITY_PORT=43190
 MY_PI_OBSERVABILITY_DB=~/.pi/agent/observability.db
+MY_PI_OBSERVABILITY_TOKEN_FILE=~/.pi/agent/observability-token
 MY_PI_OBSERVABILITY_RETENTION_DAYS=14
 MY_PI_OBSERVABILITY_MAX_EVENTS=100000
 MY_PI_OBSERVABILITY_MAX_BODY_BYTES=1048576
@@ -63,8 +64,16 @@ MY_PI_OBSERVABILITY_DETAIL=detailed # detailed or summary
 MY_PI_OBSERVABILITY_TOKEN=dev-token
 ```
 
-Open `http://127.0.0.1:43190/?token=dev-token` when a token is set.
-The dashboard includes:
+The local API requires bearer authentication by default. On first
+startup, the server creates a random token in
+`~/.pi/agent/observability-token` with mode `0600`. The token is
+shared by Pi sessions using the fixed local server; a separate random
+token per agent session would break pooled ingestion. Set
+`MY_PI_OBSERVABILITY_TOKEN` to manage the value explicitly. The TUI
+command and server startup output provide a dashboard URL whose
+fragment carries the token to the browser without sending it in an
+HTTP query string. The browser removes the fragment and sends the
+token only in the `Authorization` header. The dashboard includes:
 
 - **Trace summary** — elapsed time, blocking time, errors, token, and
   cost rollups for the selected session.
@@ -135,6 +144,15 @@ Set `MY_PI_OBSERVABILITY_DETAIL=summary` or
 Raw payload mode is opt-in with `--observability-raw` or
 `MY_PI_OBSERVABILITY_RAW=true`; redaction and a payload byte cap still
 apply.
+
+The dashboard shell and static assets are public on the configured
+listener, but event ingestion, queries, trace data, and live streams
+require an exact `Authorization: Bearer ...` header. URL query tokens
+are rejected. The token file protects against other local OS users and
+drive-by browser requests. The server also enforces mode `0600` on the
+database and its WAL/SHM files. It cannot isolate data from other
+processes running as the same account, which can already read the
+local database directly.
 
 This package does not read `.env` files automatically. Pass only the
 configuration you want through environment variables or flags.

--- a/packages/pi-observability/package.json
+++ b/packages/pi-observability/package.json
@@ -63,7 +63,7 @@
 		"@types/node": "catalog:",
 		"svelte": "catalog:",
 		"svelte-check": "catalog:",
-		"typescript": "catalog:",
+		"typescript": "^6.0.3",
 		"vite": "catalog:",
 		"vitest": "catalog:"
 	},

--- a/packages/pi-observability/src/dashboard-url.test.ts
+++ b/packages/pi-observability/src/dashboard-url.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { authenticated_dashboard_url } from './dashboard-url.js';
+
+describe('authenticated_dashboard_url', () => {
+	it('puts credentials in the fragment instead of the query string', () => {
+		const url = authenticated_dashboard_url(
+			'http://127.0.0.1:43190/',
+			'local value',
+		);
+		const parsed = new URL(url);
+
+		expect(parsed.search).toBe('');
+		expect(parsed.hash).toBe('#token=local+value');
+	});
+
+	it('leaves unauthenticated custom dashboards unchanged', () => {
+		expect(
+			authenticated_dashboard_url(
+				'https://observability.example/',
+				undefined,
+			),
+		).toBe('https://observability.example/');
+	});
+});

--- a/packages/pi-observability/src/dashboard-url.ts
+++ b/packages/pi-observability/src/dashboard-url.ts
@@ -1,0 +1,9 @@
+export function authenticated_dashboard_url(
+	url: string,
+	token: string | undefined,
+): string {
+	if (!token) return url;
+	const dashboard_url = new URL(url);
+	dashboard_url.hash = new URLSearchParams({ token }).toString();
+	return dashboard_url.toString();
+}

--- a/packages/pi-observability/src/db.test.ts
+++ b/packages/pi-observability/src/db.test.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	statSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
@@ -25,6 +31,15 @@ describe('prepare_db', () => {
 		const { db, statements } = prepare_db(db_path);
 		try {
 			expect(existsSync(db_path)).toBe(true);
+			if (process.platform !== 'win32') {
+				for (const path of [
+					db_path,
+					`${db_path}-wal`,
+					`${db_path}-shm`,
+				]) {
+					expect(statSync(path).mode & 0o777).toBe(0o600);
+				}
+			}
 			expect(Object.keys(statements).sort()).toEqual([
 				'delete_old_events',
 				'delete_orphan_sessions',

--- a/packages/pi-observability/src/db.ts
+++ b/packages/pi-observability/src/db.ts
@@ -2,7 +2,12 @@ import {
 	SQLITE_PERSISTENT_PRAGMAS,
 	sqlite_pragmas,
 } from '@spences10/pi-sqlite-core';
-import { mkdirSync, readFileSync } from 'node:fs';
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+} from 'node:fs';
 import { dirname } from 'node:path';
 import { DatabaseSync, type StatementSync } from 'node:sqlite';
 
@@ -37,6 +42,9 @@ export function prepare_db(db_path: string): {
 	db.exec(PERSISTENT_PRAGMAS);
 	db.exec(CONNECTION_PRAGMAS);
 	db.exec(SCHEMA);
+	for (const path of [db_path, `${db_path}-wal`, `${db_path}-shm`]) {
+		if (existsSync(path)) chmodSync(path, 0o600);
+	}
 	const session_columns = db
 		.prepare('PRAGMA table_info(sessions)')
 		.all() as Array<{ name: string }>;

--- a/packages/pi-observability/src/health-auth.test.ts
+++ b/packages/pi-observability/src/health-auth.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+	create_health_proof,
+	health_proof_matches,
+	valid_health_challenge,
+} from './health-auth.js';
+
+describe('health authentication', () => {
+	it('proves possession of the bearer token without transmitting it', () => {
+		const token = 'local-observability-token';
+		const challenge = 'challenge_1234567890';
+		const proof = create_health_proof(token, challenge);
+
+		expect(proof).not.toContain(token);
+		expect(health_proof_matches(token, challenge, proof)).toBe(true);
+		expect(
+			health_proof_matches('different-token', challenge, proof),
+		).toBe(false);
+	});
+
+	it.each([
+		'challenge_1234567890',
+		'550e8400-e29b-41d4-a716-446655440000',
+	])('accepts a bounded health challenge: %s', (challenge) => {
+		expect(valid_health_challenge(challenge)).toBe(true);
+	});
+
+	it.each([null, '', 'short', 'contains spaces and punctuation!'])(
+		'rejects an invalid health challenge: %s',
+		(challenge) => {
+			expect(valid_health_challenge(challenge)).toBe(false);
+		},
+	);
+});

--- a/packages/pi-observability/src/health-auth.ts
+++ b/packages/pi-observability/src/health-auth.ts
@@ -1,0 +1,34 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+const HEALTH_CHALLENGE_PATTERN = /^[A-Za-z0-9_-]{16,128}$/;
+
+export function valid_health_challenge(
+	challenge: string | null,
+): challenge is string {
+	return Boolean(
+		challenge && HEALTH_CHALLENGE_PATTERN.test(challenge),
+	);
+}
+
+export function create_health_proof(
+	token: string,
+	challenge: string,
+): string {
+	return createHmac('sha256', token)
+		.update(challenge)
+		.digest('base64url');
+}
+
+export function health_proof_matches(
+	token: string,
+	challenge: string,
+	proof: unknown,
+): boolean {
+	if (typeof proof !== 'string') return false;
+	const expected = Buffer.from(create_health_proof(token, challenge));
+	const provided = Buffer.from(proof);
+	return (
+		expected.length === provided.length &&
+		timingSafeEqual(expected, provided)
+	);
+}

--- a/packages/pi-observability/src/http-responses.test.ts
+++ b/packages/pi-observability/src/http-responses.test.ts
@@ -55,20 +55,17 @@ describe('http response helpers', () => {
 		);
 	});
 
-	it('authorizes empty tokens, query tokens, and bearer tokens', () => {
-		expect(is_authorized(new URL('http://local/'), '')).toBe(true);
+	it('fails closed and accepts only an exact bearer header', () => {
+		expect(is_authorized('', undefined)).toBe(false);
+		expect(is_authorized('expected-value', undefined)).toBe(false);
 		expect(
-			is_authorized(new URL('http://local/?token=secret'), 'secret'),
+			is_authorized('expected-value', 'Bearer expected-value'),
 		).toBe(true);
 		expect(
-			is_authorized(
-				new URL('http://local/'),
-				'secret',
-				'Bearer secret',
-			),
-		).toBe(true);
+			is_authorized('expected-value', 'Bearer different-value'),
+		).toBe(false);
 		expect(
-			is_authorized(new URL('http://local/?token=nope'), 'secret'),
+			is_authorized('expected-value', 'Basic expected-value'),
 		).toBe(false);
 	});
 

--- a/packages/pi-observability/src/http-responses.ts
+++ b/packages/pi-observability/src/http-responses.ts
@@ -1,3 +1,4 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
 export function text(
@@ -40,14 +41,18 @@ export function binary(
 	res.end(body);
 }
 
+function token_digest(value: string): Buffer {
+	return createHash('sha256').update(value).digest();
+}
+
 export function is_authorized(
-	req_url: URL,
 	token: string,
 	authorization?: string,
 ): boolean {
-	if (!token) return true;
-	if (req_url.searchParams.get('token') === token) return true;
-	return authorization === `Bearer ${token}`;
+	if (!token || !authorization?.startsWith('Bearer ')) return false;
+	const provided = authorization.slice('Bearer '.length);
+	if (!provided) return false;
+	return timingSafeEqual(token_digest(token), token_digest(provided));
 }
 
 export class BodyTooLargeError extends Error {

--- a/packages/pi-observability/src/index.test.ts
+++ b/packages/pi-observability/src/index.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import observability, {
 	create_event_envelope,
@@ -81,13 +84,17 @@ describe('resolve_dashboard_command', () => {
 });
 
 describe('resolve_observability_config', () => {
-	it('defaults to local auto-start without a server url', () => {
-		expect(
-			resolve_observability_config({ getFlag: () => undefined }, {}),
-		).toMatchObject({
+	it('defaults to authenticated local auto-start without a server url', () => {
+		const home = mkdtempSync(join(tmpdir(), 'pi-obs-config-'));
+		const config = resolve_observability_config(
+			{ getFlag: () => undefined },
+			{ HOME: home },
+		);
+		expect(config).toMatchObject({
 			server_url: 'http://127.0.0.1:43190',
 			auto_start_server: true,
 		});
+		expect(config?.token).toHaveLength(43);
 	});
 
 	it('stays disabled when explicitly disabled', () => {

--- a/packages/pi-observability/src/index.test.ts
+++ b/packages/pi-observability/src/index.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
@@ -106,6 +106,17 @@ describe('resolve_observability_config', () => {
 		).toBeNull();
 	});
 
+	it('treats empty token environment values as unconfigured', () => {
+		const home = mkdtempSync(join(tmpdir(), 'pi-obs-empty-token-'));
+		const config = resolve_observability_config(
+			{ getFlag: () => undefined },
+			{ HOME: home, MY_PI_OBSERVABILITY_TOKEN: '' },
+		);
+
+		expect(config?.token).toHaveLength(43);
+		expect(config?.auto_start_server).toBe(true);
+	});
+
 	it('uses flags and environment fallbacks', () => {
 		const flags = new Map<string, unknown>([
 			['observability-url', 'http://127.0.0.1:43190'],
@@ -128,6 +139,72 @@ describe('resolve_observability_config', () => {
 			detail_level: 'summary',
 			auto_start_server: false,
 		});
+	});
+
+	it('does not send its bearer token to an untrusted health responder', async () => {
+		const agent_dir = mkdtempSync(join(tmpdir(), 'pi-obs-health-'));
+		vi.stubEnv('PI_CODING_AGENT_DIR', agent_dir);
+		vi.stubEnv('MY_PI_OBSERVABILITY_URL', '');
+		vi.stubEnv('PI_OBSERVABILITY_URL', '');
+		vi.stubEnv('MY_PI_OBSERVABILITY_TOKEN', '');
+		vi.stubEnv('PI_OBSERVABILITY_TOKEN', '');
+		const requests: Array<{
+			authorization: string | null;
+			url: string;
+		}> = [];
+		const fetch_mock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockImplementation(async (input, init) => {
+				const url =
+					typeof input === 'string'
+						? input
+						: input instanceof URL
+							? input.href
+							: input.url;
+				requests.push({
+					authorization: new Headers(init?.headers).get(
+						'authorization',
+					),
+					url,
+				});
+				return new Response(JSON.stringify({ ok: true }), {
+					status: 200,
+				});
+			});
+		const handlers = new Map<
+			string,
+			(event: unknown, ctx: unknown) => Promise<void>
+		>();
+		const pi = {
+			registerFlag: vi.fn(),
+			registerCommand: vi.fn(),
+			getFlag: () => undefined,
+			on: (name: string, handler: never) =>
+				handlers.set(name, handler),
+		};
+		observability(pi as never);
+		const ctx = {
+			cwd: '/repo',
+			model: undefined,
+			sessionManager: {
+				getSessionId: () => 'session-1',
+				getSessionFile: () => undefined,
+				getSessionName: () => undefined,
+			},
+		};
+
+		try {
+			await expect(
+				handlers.get('session_start')?.({}, ctx),
+			).rejects.toThrow('failed authentication');
+			expect(requests).toHaveLength(1);
+			expect(requests[0].url).toContain('/health?challenge=');
+			expect(requests[0].authorization).toBeNull();
+		} finally {
+			fetch_mock.mockRestore();
+			vi.unstubAllEnvs();
+			rmSync(agent_dir, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/pi-observability/src/index.ts
+++ b/packages/pi-observability/src/index.ts
@@ -2,6 +2,8 @@ import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
+import { authenticated_dashboard_url } from './dashboard-url.js';
+import { resolve_observability_token } from './options.js';
 import {
 	redact_value,
 	safe_json,
@@ -64,13 +66,18 @@ export function resolve_observability_config(
 		as_string(pi.getFlag('observability-url')) ??
 		env.MY_PI_OBSERVABILITY_URL ??
 		env.PI_OBSERVABILITY_URL;
+	const configured_token =
+		as_string(pi.getFlag('observability-token')) ??
+		env.MY_PI_OBSERVABILITY_TOKEN ??
+		env.PI_OBSERVABILITY_TOKEN;
 
 	return {
 		server_url: configured_server_url ?? DEFAULT_OBSERVABILITY_URL,
 		token:
-			as_string(pi.getFlag('observability-token')) ??
-			env.MY_PI_OBSERVABILITY_TOKEN ??
-			env.PI_OBSERVABILITY_TOKEN,
+			configured_token ??
+			(configured_server_url
+				? undefined
+				: resolve_observability_token(env)),
 		pool:
 			as_string(pi.getFlag('observability-pool')) ??
 			env.MY_PI_OBSERVABILITY_POOL ??
@@ -276,13 +283,16 @@ async function local_server_is_running(
 	}
 }
 
-async function ensure_local_server(url: string): Promise<void> {
+async function ensure_local_server(
+	url: string,
+	token: string | undefined,
+): Promise<void> {
 	if (await local_server_is_running(url)) return;
 	const { start_observability_server } = await import('./server.js');
 	start_observability_server({
 		host: '127.0.0.1',
 		port: new URL(url).port ? Number(new URL(url).port) : 43190,
-		token: process.env.MY_PI_OBSERVABILITY_TOKEN ?? '',
+		token: token ?? '',
 		db_path:
 			process.env.MY_PI_OBSERVABILITY_DB ??
 			`${homedir()}/.pi/agent/observability.db`,
@@ -420,11 +430,18 @@ export default function observability(pi: ExtensionAPI) {
 		handler: async (args, ctx) => {
 			const command = resolve_dashboard_command(args);
 			if (config?.auto_start_server)
-				await ensure_local_server(config.server_url);
+				await ensure_local_server(config.server_url, config.token);
 			const url = config?.server_url ?? dashboard_url;
+			const authorized_url = authenticated_dashboard_url(
+				url,
+				config?.token,
+			);
 			dashboard_url = url;
 			if (command === 'url') {
-				ctx.ui.notify(`Observability dashboard: ${url}`, 'info');
+				ctx.ui.notify(
+					`Observability dashboard: ${authorized_url}`,
+					'info',
+				);
 				return;
 			}
 			if (command === 'tui') {
@@ -447,10 +464,13 @@ export default function observability(pi: ExtensionAPI) {
 				return;
 			}
 			try {
-				open_dashboard(url);
+				open_dashboard(authorized_url);
 				ctx.ui.notify(`Observability dashboard: ${url}`, 'info');
 			} catch {
-				ctx.ui.notify(`Open observability dashboard: ${url}`, 'info');
+				ctx.ui.notify(
+					`Open observability dashboard: ${authorized_url}`,
+					'info',
+				);
 			}
 		},
 	});
@@ -487,7 +507,7 @@ export default function observability(pi: ExtensionAPI) {
 		if (!config) return;
 		dashboard_url = config.server_url;
 		if (config.auto_start_server)
-			await ensure_local_server(config.server_url);
+			await ensure_local_server(config.server_url, config.token);
 		seq = 0;
 		session = {
 			session_id: ctx.sessionManager.getSessionId(),

--- a/packages/pi-observability/src/index.ts
+++ b/packages/pi-observability/src/index.ts
@@ -1,8 +1,10 @@
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import type { Server } from 'node:http';
 import { homedir } from 'node:os';
 import { authenticated_dashboard_url } from './dashboard-url.js';
+import { health_proof_matches } from './health-auth.js';
 import { resolve_observability_token } from './options.js';
 import {
 	redact_value,
@@ -64,12 +66,12 @@ export function resolve_observability_config(
 
 	const configured_server_url =
 		as_string(pi.getFlag('observability-url')) ??
-		env.MY_PI_OBSERVABILITY_URL ??
-		env.PI_OBSERVABILITY_URL;
+		as_string(env.MY_PI_OBSERVABILITY_URL) ??
+		as_string(env.PI_OBSERVABILITY_URL);
 	const configured_token =
 		as_string(pi.getFlag('observability-token')) ??
-		env.MY_PI_OBSERVABILITY_TOKEN ??
-		env.PI_OBSERVABILITY_TOKEN;
+		as_string(env.MY_PI_OBSERVABILITY_TOKEN) ??
+		as_string(env.PI_OBSERVABILITY_TOKEN);
 
 	return {
 		server_url: configured_server_url ?? DEFAULT_OBSERVABILITY_URL,
@@ -272,24 +274,60 @@ export function create_event_envelope(
 	};
 }
 
-async function local_server_is_running(
+type LocalServerStatus = 'authenticated' | 'absent' | 'untrusted';
+
+async function local_server_status(
 	url: string,
-): Promise<boolean> {
+	token: string | undefined,
+): Promise<LocalServerStatus> {
+	if (!token) return 'untrusted';
+	const challenge = randomUUID();
 	try {
-		const response = await fetch(`${url.replace(/\/+$/, '')}/health`);
-		return response.ok;
+		const response = await fetch(
+			`${url.replace(/\/+$/, '')}/health?challenge=${encodeURIComponent(challenge)}`,
+		);
+		if (!response.ok) return 'untrusted';
+		const body = (await response.json()) as { proof?: unknown };
+		return health_proof_matches(token, challenge, body.proof)
+			? 'authenticated'
+			: 'untrusted';
 	} catch {
-		return false;
+		return 'absent';
 	}
+}
+
+async function wait_for_server_listening(
+	server: Server,
+): Promise<void> {
+	if (server.listening) return;
+	await new Promise<void>((resolve_listening, reject_listening) => {
+		const on_listening = () => {
+			server.off('error', on_error);
+			resolve_listening();
+		};
+		const on_error = (error: Error) => {
+			server.off('listening', on_listening);
+			reject_listening(error);
+		};
+		server.once('listening', on_listening);
+		server.once('error', on_error);
+	});
 }
 
 async function ensure_local_server(
 	url: string,
 	token: string | undefined,
 ): Promise<void> {
-	if (await local_server_is_running(url)) return;
+	const status = await local_server_status(url, token);
+	if (status === 'authenticated') return;
+	if (status === 'untrusted') {
+		throw new Error(
+			`Observability endpoint at ${url} failed authentication`,
+		);
+	}
+
 	const { start_observability_server } = await import('./server.js');
-	start_observability_server({
+	const running = start_observability_server({
 		host: '127.0.0.1',
 		port: new URL(url).port ? Number(new URL(url).port) : 43190,
 		token: token ?? '',
@@ -299,6 +337,13 @@ async function ensure_local_server(
 		log: false,
 		throw_on_listen_error: false,
 	});
+	await wait_for_server_listening(running.server);
+	if ((await local_server_status(url, token)) !== 'authenticated') {
+		await running.close();
+		throw new Error(
+			`Observability server at ${url} failed startup authentication`,
+		);
+	}
 }
 
 export function open_dashboard(url: string): void {

--- a/packages/pi-observability/src/options.test.ts
+++ b/packages/pi-observability/src/options.test.ts
@@ -1,20 +1,37 @@
+import { mkdtempSync, readFileSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { resolve_observability_server_options } from './options.js';
+import {
+	resolve_observability_server_options,
+	resolve_observability_token,
+} from './options.js';
 
 describe('resolve_observability_server_options', () => {
-	it('uses safe local defaults', () => {
-		const options = resolve_observability_server_options({
-			HOME: '/home/test',
-		});
+	it('generates and reuses a private local token by default', () => {
+		const home = mkdtempSync(join(tmpdir(), 'pi-obs-options-'));
+		const env = { HOME: home };
+		const options = resolve_observability_server_options(env);
+		const token_path = join(
+			home,
+			'.pi',
+			'agent',
+			'observability-token',
+		);
 
 		expect(options).toMatchObject({
 			host: '127.0.0.1',
 			port: 43190,
-			token: '',
 			log: true,
 			retention_days: 14,
 			max_events: 100_000,
 		});
+		expect(options.token).toHaveLength(43);
+		expect(resolve_observability_token(env)).toBe(options.token);
+		expect(readFileSync(token_path, 'utf8').trim()).toBe(
+			options.token,
+		);
+		expect(statSync(token_path).mode & 0o777).toBe(0o600);
 		expect(options.db_path).toContain('.pi/agent/observability.db');
 	});
 
@@ -45,6 +62,7 @@ describe('resolve_observability_server_options', () => {
 				MY_PI_OBSERVABILITY_PORT: '70000',
 				MY_PI_OBSERVABILITY_RETENTION_DAYS: '0',
 				MY_PI_OBSERVABILITY_MAX_EVENTS: 'nope',
+				MY_PI_OBSERVABILITY_TOKEN: 'configured-value',
 			}),
 		).toMatchObject({
 			port: 43190,

--- a/packages/pi-observability/src/options.ts
+++ b/packages/pi-observability/src/options.ts
@@ -1,5 +1,12 @@
+import { randomBytes } from 'node:crypto';
+import {
+	chmodSync,
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+} from 'node:fs';
 import { homedir } from 'node:os';
-import { resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import type { ObservabilityServerOptions } from './server-options.js';
 
 function parse_positive_integer(
@@ -17,13 +24,65 @@ function parse_port(value: string | undefined): number {
 	return port;
 }
 
+export function generate_observability_token(): string {
+	return randomBytes(32).toString('base64url');
+}
+
+function default_token_path(env: NodeJS.ProcessEnv): string {
+	const agent_dir =
+		env.PI_CODING_AGENT_DIR ??
+		join(env.HOME ?? homedir(), '.pi', 'agent');
+	return resolve(
+		env.MY_PI_OBSERVABILITY_TOKEN_FILE ??
+			join(agent_dir, 'observability-token'),
+	);
+}
+
+export function resolve_observability_token(
+	env: NodeJS.ProcessEnv = process.env,
+): string {
+	const configured = env.MY_PI_OBSERVABILITY_TOKEN?.trim();
+	if (configured) return configured;
+
+	const path = default_token_path(env);
+	try {
+		const existing = readFileSync(path, 'utf8').trim();
+		if (!existing)
+			throw new Error(`Observability token file is empty: ${path}`);
+		chmodSync(path, 0o600);
+		return existing;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== 'ENOENT')
+			throw error;
+	}
+
+	mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+	const generated = generate_observability_token();
+	try {
+		writeFileSync(path, `${generated}\n`, {
+			encoding: 'utf8',
+			flag: 'wx',
+			mode: 0o600,
+		});
+		return generated;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== 'EEXIST')
+			throw error;
+		const existing = readFileSync(path, 'utf8').trim();
+		if (!existing)
+			throw new Error(`Observability token file is empty: ${path}`);
+		chmodSync(path, 0o600);
+		return existing;
+	}
+}
+
 export function resolve_observability_server_options(
 	env: NodeJS.ProcessEnv = process.env,
 ): ObservabilityServerOptions {
 	return {
 		host: env.MY_PI_OBSERVABILITY_HOST ?? '127.0.0.1',
 		port: parse_port(env.MY_PI_OBSERVABILITY_PORT),
-		token: env.MY_PI_OBSERVABILITY_TOKEN ?? '',
+		token: resolve_observability_token(env),
 		db_path: resolve(
 			env.MY_PI_OBSERVABILITY_DB ??
 				`${homedir()}/.pi/agent/observability.db`,

--- a/packages/pi-observability/src/server-options.ts
+++ b/packages/pi-observability/src/server-options.ts
@@ -17,6 +17,7 @@ export interface RunningObservabilityServer {
 	server: Server;
 	db: DatabaseSync;
 	url: string;
+	token: string;
 	db_path: string;
 	close: () => Promise<void>;
 }

--- a/packages/pi-observability/src/server.test.ts
+++ b/packages/pi-observability/src/server.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import { create_health_proof } from './health-auth.js';
 import {
 	resolve_observability_server_options,
 	start_observability_server,
@@ -51,7 +52,9 @@ function test_port(): number {
 async function wait_for_health(url: string): Promise<void> {
 	for (let attempt = 0; attempt < 50; attempt++) {
 		try {
-			const response = await fetch(`${url}/health`);
+			const response = await fetch(
+				`${url}/health?challenge=test-health-challenge`,
+			);
 			if (response.ok) return;
 		} catch {
 			// wait and retry
@@ -108,6 +111,28 @@ describe('resolve_observability_server_options', () => {
 });
 
 describe('start_observability_server', () => {
+	it('returns a token-bound proof for health challenges', async () => {
+		const server = start_observability_server({
+			host: '127.0.0.1',
+			port: test_port(),
+			token: 'health-proof-token',
+			db_path: tmp_db_path(),
+			log: false,
+		});
+		servers.push(server);
+		await wait_for_health(server.url);
+
+		const challenge = 'health-proof-challenge';
+		const response = await fetch(
+			`${server.url}/health?challenge=${challenge}`,
+		);
+		expect(await response.json()).toEqual({
+			ok: true,
+			proof: create_health_proof(server.token, challenge),
+		});
+		expect((await fetch(`${server.url}/health`)).status).toBe(400);
+	});
+
 	it('ingests events and exposes session history', async () => {
 		const server = start_observability_server({
 			host: '127.0.0.1',

--- a/packages/pi-observability/src/server.test.ts
+++ b/packages/pi-observability/src/server.test.ts
@@ -11,6 +11,29 @@ import type { ObservabilityEvent } from './types.js';
 
 const servers: RunningObservabilityServer[] = [];
 
+async function fetch(
+	input: string | URL | Request,
+	init: RequestInit = {},
+): Promise<Response> {
+	const url =
+		typeof input === 'string'
+			? input
+			: input instanceof URL
+				? input.href
+				: input.url;
+	const server = servers.find((candidate) =>
+		url.startsWith(candidate.url),
+	);
+	const headers = new Headers(init.headers);
+	if (
+		server &&
+		!new URL(url).searchParams.has('unauthorized') &&
+		!new URL(url).searchParams.has('token')
+	)
+		headers.set('authorization', `Bearer ${server.token}`);
+	return globalThis.fetch(input, { ...init, headers });
+}
+
 afterEach(async () => {
 	while (servers.length > 0) {
 		await servers.pop()?.close();
@@ -78,6 +101,7 @@ describe('resolve_observability_server_options', () => {
 		expect(
 			resolve_observability_server_options({
 				MY_PI_OBSERVABILITY_PORT: 'not-a-port',
+				MY_PI_OBSERVABILITY_TOKEN: 'configured-value',
 			}).port,
 		).toBe(43190);
 	});
@@ -442,7 +466,7 @@ describe('start_observability_server', () => {
 		expect(events_body.events[0]?.seq).toBe(100);
 	});
 
-	it('requires auth when a token is configured', async () => {
+	it('requires header auth and rejects query tokens', async () => {
 		const server = start_observability_server({
 			host: '127.0.0.1',
 			port: test_port(),
@@ -453,10 +477,13 @@ describe('start_observability_server', () => {
 		servers.push(server);
 		await wait_for_health(server.url);
 
-		expect((await fetch(`${server.url}/sessions`)).status).toBe(401);
+		expect(
+			(await fetch(`${server.url}/sessions?unauthorized=1`)).status,
+		).toBe(401);
 		expect(
 			(await fetch(`${server.url}/sessions?token=dev-token`)).status,
-		).toBe(200);
+		).toBe(401);
+		expect((await fetch(`${server.url}/sessions`)).status).toBe(200);
 	});
 
 	it('broadcasts ingested events to SSE subscribers', async () => {

--- a/packages/pi-observability/src/server.ts
+++ b/packages/pi-observability/src/server.ts
@@ -11,6 +11,7 @@ import {
 	read_dashboard_font,
 	render_dashboard,
 } from './assets.js';
+import { authenticated_dashboard_url } from './dashboard-url.js';
 import { prepare_db } from './db.js';
 import {
 	to_row_event,
@@ -25,7 +26,10 @@ import {
 	read_body,
 	text,
 } from './http-responses.js';
-import { resolve_observability_server_options } from './options.js';
+import {
+	generate_observability_token,
+	resolve_observability_server_options,
+} from './options.js';
 import { describe_port_owner } from './port-owner.js';
 import type {
 	ObservabilityServerOptions,
@@ -68,6 +72,7 @@ function bounded_limit(
 export function start_observability_server(
 	options: ObservabilityServerOptions = resolve_observability_server_options(),
 ): RunningObservabilityServer {
+	const token = options.token || generate_observability_token();
 	const { db, statements } = prepare_db(options.db_path);
 	let next_subscriber_id = 1;
 	const subscribers = new Map<number, Subscriber>();
@@ -183,13 +188,7 @@ export function start_observability_server(
 				const font = read_dashboard_font(req_url.pathname);
 				if (font) return binary(res, 200, 'font/woff2', font);
 			}
-			if (
-				!is_authorized(
-					req_url,
-					options.token,
-					req.headers.authorization,
-				)
-			) {
+			if (!is_authorized(token, req.headers.authorization)) {
 				return json(res, 401, { error: 'unauthorized' });
 			}
 			if (req_url.pathname === '/events' && req.method === 'POST') {
@@ -360,8 +359,10 @@ export function start_observability_server(
 
 	server.listen(options.port, options.host, () => {
 		if (!options.log) return;
+		const url = `http://${options.host}:${options.port}`;
+		console.log(`My-Pi observability listening on ${url}`);
 		console.log(
-			`My-Pi observability listening on http://${options.host}:${options.port}`,
+			`Dashboard: ${authenticated_dashboard_url(url, token)}`,
 		);
 		console.log(`Database: ${options.db_path}`);
 	});
@@ -370,6 +371,7 @@ export function start_observability_server(
 		server,
 		db,
 		url: `http://${options.host}:${options.port}`,
+		token,
 		db_path: options.db_path,
 		close: async () => {
 			clearInterval(heartbeat);

--- a/packages/pi-observability/src/server.ts
+++ b/packages/pi-observability/src/server.ts
@@ -14,6 +14,10 @@ import {
 import { authenticated_dashboard_url } from './dashboard-url.js';
 import { prepare_db } from './db.js';
 import {
+	create_health_proof,
+	valid_health_challenge,
+} from './health-auth.js';
+import {
 	to_row_event,
 	to_session_row,
 	valid_event,
@@ -165,7 +169,16 @@ export function start_observability_server(
 			);
 			if (req.method === 'OPTIONS') return json(res, 200, {});
 			if (req_url.pathname === '/health') {
-				return json(res, 200, { ok: true });
+				const challenge = req_url.searchParams.get('challenge');
+				if (!valid_health_challenge(challenge)) {
+					return json(res, 400, {
+						error: 'valid health challenge required',
+					});
+				}
+				return json(res, 200, {
+					ok: true,
+					proof: create_health_proof(token, challenge),
+				});
 			}
 			if (req_url.pathname === '/') {
 				return text(

--- a/packages/pi-observability/src/tui-dashboard.ts
+++ b/packages/pi-observability/src/tui-dashboard.ts
@@ -12,6 +12,7 @@ import {
 	truncateToWidth,
 } from '@earendil-works/pi-tui';
 import { show_modal } from '@spences10/pi-tui-modal';
+import { authenticated_dashboard_url } from './dashboard-url.js';
 import { open_dashboard } from './index.js';
 
 interface DashboardSession {
@@ -465,7 +466,9 @@ export async function show_observability_tui_dashboard(
 					} else if (matchesKey(data, Key.ctrl('r'))) {
 						void refresh();
 					} else if (view === 'event' && data === 'b') {
-						open_dashboard(server_url);
+						open_dashboard(
+							authenticated_dashboard_url(server_url, token),
+						);
 					} else if (data === 'q') {
 						done();
 					} else if (view !== 'event') {

--- a/packages/pi-observability/src/tui-dashboard.ts
+++ b/packages/pi-observability/src/tui-dashboard.ts
@@ -41,14 +41,11 @@ interface DashboardSnapshot {
 	loaded_at: Date;
 }
 
-function api_url(
-	server_url: string,
-	path: string,
-	token?: string,
-): string {
-	const url = new URL(path, server_url.replace(/\/+$/, '') + '/');
-	if (token) url.searchParams.set('token', token);
-	return url.toString();
+function api_url(server_url: string, path: string): string {
+	return new URL(
+		path,
+		server_url.replace(/\/+$/, '') + '/',
+	).toString();
 }
 
 async function fetch_json<T>(
@@ -58,7 +55,7 @@ async function fetch_json<T>(
 ): Promise<T> {
 	const headers: Record<string, string> = {};
 	if (token) headers.authorization = `Bearer ${token}`;
-	const response = await fetch(api_url(server_url, path, token), {
+	const response = await fetch(api_url(server_url, path), {
 		headers,
 	});
 	if (!response.ok) throw new Error(`HTTP ${response.status}`);

--- a/packages/pi-observability/src/web/src/dashboard-state.svelte.ts
+++ b/packages/pi-observability/src/web/src/dashboard-state.svelte.ts
@@ -11,7 +11,19 @@ type Event = ObservabilityEvent<Record<string, unknown>>;
 type Session = DashboardSession;
 type View = 'timeline' | 'waterfall' | 'events';
 
-const token = new URLSearchParams(location.search).get('token') || '';
+function read_fragment_token() {
+	const fragment = new URLSearchParams(location.hash.slice(1));
+	const token = fragment.get('token') || '';
+	if (token)
+		history.replaceState(
+			null,
+			'',
+			`${location.pathname}${location.search}`,
+		);
+	return token;
+}
+
+const token = read_fragment_token();
 const theme_key = 'pi-observability-theme';
 const details_key = 'pi-observability-details-open';
 
@@ -40,8 +52,12 @@ let session_reload_timer: ReturnType<typeof setTimeout> | null = null;
 let selected_reload_timer: ReturnType<typeof setTimeout> | null =
 	null;
 
-export function api(path: string) {
-	return `${path}${token ? `${path.includes('?') ? '&' : '?'}token=${encodeURIComponent(token)}` : ''}`;
+async function api_fetch(path: string, init: RequestInit = {}) {
+	const headers = new Headers(init.headers);
+	if (token) headers.set('authorization', `Bearer ${token}`);
+	const response = await fetch(path, { ...init, headers });
+	if (!response.ok) throw new Error(`HTTP ${response.status}`);
+	return response;
 }
 
 export function label(session: Session) {
@@ -212,7 +228,7 @@ export function toggle_details_open() {
 }
 
 export async function load_sessions() {
-	const response = await fetch(api('/sessions'));
+	const response = await api_fetch('/sessions');
 	const body = await response.json();
 	dashboard_state.sessions = body.sessions || [];
 	if (!dashboard_state.selected_id && dashboard_state.sessions[0])
@@ -228,8 +244,8 @@ function sync_selected_event(events: Event[]) {
 }
 
 export async function fetch_events(id: string) {
-	const response = await fetch(
-		api(`/sessions/${encodeURIComponent(id)}/events?limit=500`),
+	const response = await api_fetch(
+		`/sessions/${encodeURIComponent(id)}/events?limit=500`,
 	);
 	const body = await response.json();
 	const loaded = (body.events || []) as Event[];
@@ -247,7 +263,7 @@ export async function select_session(id: string) {
 	if (previous_id !== id) dashboard_state.selected_event = null;
 	const [loaded_events, trace_response] = await Promise.all([
 		fetch_events(id),
-		fetch(api(`/sessions/${encodeURIComponent(id)}/trace`)),
+		api_fetch(`/sessions/${encodeURIComponent(id)}/trace`),
 	]);
 	dashboard_state.events = loaded_events;
 	sync_selected_event(loaded_events);
@@ -270,44 +286,79 @@ function schedule_selected_reload() {
 	}, 350);
 }
 
-export function connect() {
-	const source = new EventSource(api('/events/stream'));
-	source.addEventListener(
-		'hello',
-		() => (dashboard_state.connected = true),
-	);
-	source.addEventListener('event', (message) => {
-		const event = JSON.parse(message.data) as Event;
-		dashboard_state.live_seen = {
-			...dashboard_state.live_seen,
-			[event.session_id]: Date.now(),
-		};
-		if (event.type === 'session_shutdown') {
-			const next = { ...dashboard_state.live_seen };
-			delete next[event.session_id];
-			dashboard_state.live_seen = next;
-		}
-		if (dashboard_state.paused) return;
-		const cached = event_cache.get(event.session_id) || [];
-		if (!cached.some((item) => item.event_id === event.event_id)) {
-			event_cache.set(
-				event.session_id,
-				[event, ...cached].slice(0, 500),
-			);
-			if (event.session_id === dashboard_state.selected_id) {
-				dashboard_state.events =
-					event_cache.get(event.session_id) || [];
-				sync_selected_event(dashboard_state.events);
-			}
-		}
-		schedule_sessions_reload();
-		if (event.session_id === dashboard_state.selected_id)
-			schedule_selected_reload();
-	});
-	source.onerror = () => {
-		dashboard_state.connected = false;
-		source.close();
-		setTimeout(connect, 1500);
+function receive_event(event: Event) {
+	dashboard_state.live_seen = {
+		...dashboard_state.live_seen,
+		[event.session_id]: Date.now(),
 	};
-	return () => source.close();
+	if (event.type === 'session_shutdown') {
+		const next = { ...dashboard_state.live_seen };
+		delete next[event.session_id];
+		dashboard_state.live_seen = next;
+	}
+	if (dashboard_state.paused) return;
+	const cached = event_cache.get(event.session_id) || [];
+	if (!cached.some((item) => item.event_id === event.event_id)) {
+		event_cache.set(
+			event.session_id,
+			[event, ...cached].slice(0, 500),
+		);
+		if (event.session_id === dashboard_state.selected_id) {
+			dashboard_state.events =
+				event_cache.get(event.session_id) || [];
+			sync_selected_event(dashboard_state.events);
+		}
+	}
+	schedule_sessions_reload();
+	if (event.session_id === dashboard_state.selected_id)
+		schedule_selected_reload();
+}
+
+function receive_frame(frame: string) {
+	let type = 'message';
+	const data: string[] = [];
+	for (const line of frame.split(/\r?\n/)) {
+		if (line.startsWith('event:')) type = line.slice(6).trim();
+		if (line.startsWith('data:'))
+			data.push(line.slice(5).trimStart());
+	}
+	if (type === 'hello') {
+		dashboard_state.connected = true;
+		return;
+	}
+	if (type === 'event' && data.length > 0)
+		receive_event(JSON.parse(data.join('\n')) as Event);
+}
+
+async function consume_stream(signal: AbortSignal) {
+	while (!signal.aborted) {
+		try {
+			const response = await api_fetch('/events/stream', { signal });
+			const reader = response.body?.getReader();
+			if (!reader) throw new Error('Missing event stream body');
+			const decoder = new TextDecoder();
+			let buffered = '';
+			while (!signal.aborted) {
+				const chunk = await reader.read();
+				if (chunk.done) break;
+				buffered += decoder.decode(chunk.value, { stream: true });
+				const frames = buffered.split(/\r?\n\r?\n/);
+				buffered = frames.pop() || '';
+				for (const frame of frames) receive_frame(frame);
+			}
+		} catch {
+			if (signal.aborted) return;
+		} finally {
+			dashboard_state.connected = false;
+		}
+		await new Promise((resolve_wait) =>
+			setTimeout(resolve_wait, 1500),
+		);
+	}
+}
+
+export function connect() {
+	const controller = new AbortController();
+	void consume_stream(controller.signal);
+	return () => controller.abort();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -544,10 +544,10 @@ importers:
         version: 5.56.5
       svelte-check:
         specifier: 'catalog:'
-        version: 4.7.3(picomatch@4.0.5)(svelte@5.56.5)(typescript@7.0.2)
+        version: 4.7.3(picomatch@4.0.5)(svelte@5.56.5)(typescript@6.0.3)
       typescript:
-        specifier: 'catalog:'
-        version: 7.0.2
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: 'catalog:'
         version: 8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
@@ -6542,6 +6542,19 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  svelte-check@4.7.3(picomatch@4.0.5)(svelte@5.56.5)(typescript@6.0.3):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@sveltejs/load-config': 0.2.0
+      chokidar: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.5)
+      picocolors: 1.1.1
+      sade: 1.8.1
+      svelte: 5.56.5
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - picomatch
+
   svelte-check@4.7.3(picomatch@4.0.5)(svelte@5.56.5)(typescript@7.0.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -6630,8 +6643,7 @@ snapshots:
 
   typebox@1.3.6: {}
 
-  typescript@6.0.3:
-    optional: true
+  typescript@6.0.3: {}
 
   typescript@7.0.2:
     optionalDependencies:


### PR DESCRIPTION
## Summary

- prevent project MCP policy from widening global activation rules
- generate and persist header-only observability bearer authentication with constant-time comparison and restrictive file permissions
- add regression coverage and update MCP/observability documentation
- add a GitHub Actions trusted-publishing workflow and release documentation

## Validation

- affected package checks and tests
- root check, test, and build
- frozen install
- Svelte checks and autofixer
- final diff checks
- live observability API authentication and token-file permission verification

LSP diagnostics were attempted on the remote worker, but `typescript-language-server` was unavailable there.

## Manual follow-up

Repository owners must configure the GitHub `npm` environment and npm trusted publishers for every package before publishing through the new workflow.

Closes #373
