### PR TITLE
fix(factory): avoid redundant routine delivery routing

### DIFF
--- a/.changeset/calm-tools-route.md
+++ b/.changeset/calm-tools-route.md
@@ -1,0 +1,7 @@
+---
+'@spences10/pi-factory': patch
+'my-pi': patch
+---
+
+Clarify factory routing so routine commits and pushes remain direct
+while managed approvals stay explicit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,14 @@ Keep skill metadata activation-friendly:
 ## Commit and Changeset ownership
 
 Do not commit changes or create a Changeset unless the user explicitly
-requests that action. By default, stop after validation so the user
-can review the implementation, then let the user create the Changeset
-or request that it be created and committed.
+requests that action. An explicitly authorized commit or push for a
+bounded, low-risk, single-session change does not require factory
+routing by itself. Reserve factory delivery for ambiguous or high-risk
+work, coordinated delivery, or requests that need review gates. Once
+work is factory-managed, retain its explicit approval boundaries. By
+default, stop after validation so the user can review the
+implementation, then let the user create the Changeset or request that
+it be created and committed.
 
 ## Validation
 

--- a/packages/pi-factory/README.md
+++ b/packages/pi-factory/README.md
@@ -24,6 +24,13 @@ intake → explained route → harness contract → execute → validate/retry
        → independent review → explicit approval → outcome/metrics
 ```
 
+Use factory workflows for ambiguous or high-risk work, coordinated
+delivery, or requests that need review gates. A bounded routine change
+in one coding session does not need factory routing solely because the
+user explicitly authorized a commit or push. If work is factory-
+managed, its requested side effects remain pending approval actions;
+the request itself is not a factory approval decision.
+
 Use `/factory preview <task>` before `/factory start <task>`. The
 `factory` tool exposes the same routing and state-machine semantics to
 TUI, print/JSON, RPC, and SDK consumers. Intake risk hints may only

--- a/packages/pi-factory/skills/software-factory/SKILL.md
+++ b/packages/pi-factory/skills/software-factory/SKILL.md
@@ -7,6 +7,13 @@ compatibility: Requires Pi with the @spences10/pi-factory extension.
 
 # Software Factory
 
+Use this workflow for ambiguous or high-risk work, coordinated
+delivery, or requests that need review gates. Do not invoke it solely
+because a bounded routine single-session change includes an explicitly
+authorized commit or push. Once work enters factory management, retain
+its explicit approval nodes; a requested side effect is not itself a
+factory approval decision.
+
 1. Preview with `factory action=preview`; explain workflow/version,
    policy sources, compute, parallelism, validations, retry limits,
    review mode, ownership, and approvals.

--- a/packages/pi-factory/src/extension.ts
+++ b/packages/pi-factory/src/extension.ts
@@ -518,6 +518,15 @@ export function assert_manual_node_authority(
 		`Execution, review, and validation nodes can only be ${action === 'start' ? 'started' : 'completed'} by the authoritative controller`,
 	);
 }
+export const factory_prompt_guidelines = [
+	'Use factory workflows for ambiguous or high-risk work, coordinated delivery, or requests that need review gates.',
+	'An explicitly authorized routine single-session commit or push does not require factory routing by itself.',
+	'Once work is factory-managed, preserve its explicit approval nodes; requested side effects are not approval decisions.',
+	'Use preview before create so the explained route can be overridden.',
+	'Never infer approval from validation, mailbox delivery, silence, or model output.',
+	'Team Mode supplies peer evidence only; it does not supervise sessions.',
+];
+
 export function factory_intake_from_extension(input: {
 	task: string;
 	cwd: string;
@@ -853,11 +862,7 @@ export default async function factory(pi: ExtensionAPI) {
 			'Preview, create, operate, recover, review, approve, measure workflows, and author repository factory policy.',
 		promptSnippet:
 			'Dispatch and operate governed software-factory workflows',
-		promptGuidelines: [
-			'Use preview before create so the explained route can be overridden.',
-			'Never infer approval from validation, mailbox delivery, silence, or model output.',
-			'Team Mode supplies peer evidence only; it does not supervise sessions.',
-		],
+		promptGuidelines: factory_prompt_guidelines,
 		parameters: params_schema,
 		async execute(_id, params, _signal, _update, ctx) {
 			assert_child_factory_authority(

--- a/packages/pi-factory/src/factory.test.ts
+++ b/packages/pi-factory/src/factory.test.ts
@@ -37,6 +37,7 @@ import {
 	assert_manual_node_authority,
 	capture_git_workspace,
 	factory_intake_from_extension,
+	factory_prompt_guidelines,
 	resolve_factory_owner,
 	validate_adoptable_harness,
 } from './extension.js';
@@ -111,6 +112,14 @@ function feedback(
 }
 
 describe('catalog, policy, and dispatch', () => {
+	it('guides already-authorized routine delivery directly while preserving managed approvals', () => {
+		expect(factory_prompt_guidelines).toContain(
+			'An explicitly authorized routine single-session commit or push does not require factory routing by itself.',
+		);
+		expect(factory_prompt_guidelines).toContain(
+			'Once work is factory-managed, preserve its explicit approval nodes; requested side effects are not approval decisions.',
+		);
+	});
 	it('provides eight materially distinct versioned workflows', () => {
 		const ids = [
 			'chore',


### PR DESCRIPTION
## Summary

- route bounded, low-risk, single-session work directly when commit or push was explicitly authorized
- retain explicit approval nodes after work enters factory management or review-gated Team Mode delivery
- document the boundary in runtime prompt guidance, package guidance, and repository guidance
- add focused regression coverage for the runtime prompt guidance

Closes #371

## Validation

- `pnpm --filter @spences10/pi-factory run check:self`
- `pnpm --filter @spences10/pi-factory run test:self` — 150 tests passed
- `pnpx check-skills validate packages/pi-factory/skills/software-factory --json`
- `pnpx check-skills validate .agents --recursive --json`
- `pnpm run check` — passed; emitted 15 architecture advisories and observability font-resolution build warnings
- `pnpm changeset status` — patch bumps for `@spences10/pi-factory` and `my-pi`
- `git diff --check`
- Changeset prose word count explicitly verified as 15
- changed-file LSP diagnostics attempted for both edited TypeScript files; the runtime TypeScript language server could not initialize, while package and root TypeScript checks passed

## Risks

- Changed-file LSP diagnostics remain unavailable because the current TypeScript language server cannot initialize with the workspace TypeScript installation.
- Factory dispatch approval behavior is intentionally unchanged: requested side effects remain gated once work is factory-managed.

## Changeset description

Clarify factory routing so routine commits and pushes remain direct while managed approvals stay explicit.

