### PR TITLE
fix: fail fast on unsupported Node

### DIFF
--- a/.changeset/calm-pianos-start.md
+++ b/.changeset/calm-pianos-start.md
@@ -1,0 +1,6 @@
+---
+'my-pi': patch
+---
+
+Fail fast on unsupported Node versions and document deterministic pnpm
+eleven first-run build approval guidance.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ SDK. Use the full distribution directly, or install individual
 ## Quick start
 
 ```bash
-pnpx my-pi@latest
+pnpx --allow-build=@google/genai --allow-build=protobufjs my-pi@latest
 # or: npx my-pi@latest / bunx my-pi@latest
 ```
 
@@ -29,7 +29,7 @@ pnpx my-pi@latest
 Use `my-pi` if you want the complete, opinionated setup:
 
 ```bash
-pnpx my-pi@latest
+pnpx --allow-build=@google/genai --allow-build=protobufjs my-pi@latest
 ```
 
 This is its own CLI wrapper around Pi. Do not install the root package
@@ -89,6 +89,22 @@ instructions, commands, configuration, and runtime behavior.
 observability packages. The CLI suppresses Node's expected
 `node:sqlite` `ExperimentalWarning`; standalone package/API consumers
 own their process warning policy until Node marks it stable.
+
+### pnpm 11 first-run build approval
+
+pnpm 11 asks for interactive approval before running the transitive
+`@google/genai` preinstall and `protobufjs` postinstall hooks. Neither
+hook builds runtime artifacts: the first prints a no-op message and
+the second only checks dependency version syntax. Declining them does
+not degrade `my-pi` functionality.
+
+For a deterministic first run, or after accidentally selecting `No`,
+rerun the Quick start command with both `--allow-build` flags. It
+allows those two known hooks without the two-stage selection and
+confirmation prompt. The package does not publish a `pnpm` settings
+block because pnpm 11 ignores package-level build policy. The
+`node-domexception` deprecation notice is also transitive and does not
+affect runtime behavior.
 
 ## Common usage
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,14 @@ import {
 	parse_tool_excludelist,
 	resolve_builtin_extension_options,
 } from './cli-args.js';
+import { get_node_preflight_error } from './runtime-preflight.js';
 import { install_sqlite_warning_filter } from './warnings.js';
+
+const node_preflight_error = get_node_preflight_error();
+if (node_preflight_error) {
+	console.error(node_preflight_error);
+	process.exit(1);
+}
 
 install_sqlite_warning_filter();
 

--- a/src/package-smoke.test.ts
+++ b/src/package-smoke.test.ts
@@ -1,5 +1,10 @@
-import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -10,6 +15,18 @@ interface PackFile {
 
 interface PackResult {
 	files: PackFile[];
+}
+
+function write_node_version_preload(
+	directory: string,
+	version: string,
+): string {
+	const path = join(directory, 'node-version.cjs');
+	writeFileSync(
+		path,
+		`Object.defineProperty(process.versions, 'node', { value: ${JSON.stringify(version)} });\n`,
+	);
+	return path;
 }
 
 describe('package smoke', () => {
@@ -28,10 +45,12 @@ describe('package smoke', () => {
 		) as {
 			bin?: Record<string, string>;
 			exports?: Record<string, unknown>;
+			pnpm?: unknown;
 		};
 
 		expect(package_json.bin?.['my-pi']).toBe('./dist/index.js');
 		expect(package_json.exports).toHaveProperty('.');
+		expect(package_json.pnpm).toBeUndefined();
 		for (const expected of [
 			'package.json',
 			'README.md',
@@ -43,12 +62,16 @@ describe('package smoke', () => {
 		}
 	});
 
-	it('runs the packed CLI help without user-global agent state', () => {
+	it('runs the packed CLI help at the minimum Node version', () => {
 		const agent_dir = mkdtempSync(join(tmpdir(), 'my-pi-cli-smoke-'));
 		try {
+			const preload = write_node_version_preload(
+				agent_dir,
+				'24.15.0',
+			);
 			const output = execFileSync(
 				process.execPath,
-				['dist/index.js', '--help'],
+				['--require', preload, 'dist/index.js', '--help'],
 				{
 					encoding: 'utf-8',
 					env: {
@@ -60,6 +83,35 @@ describe('package smoke', () => {
 
 			expect(output).toContain('my-pi');
 			expect(output).toContain('--agent-dir');
+		} finally {
+			rmSync(agent_dir, { recursive: true, force: true });
+		}
+	});
+
+	it('fails the packed CLI cleanly below the minimum Node version', () => {
+		const agent_dir = mkdtempSync(join(tmpdir(), 'my-pi-cli-smoke-'));
+		try {
+			const preload = write_node_version_preload(
+				agent_dir,
+				'24.14.0',
+			);
+			const result = spawnSync(
+				process.execPath,
+				['--require', preload, 'dist/index.js', '--help'],
+				{
+					encoding: 'utf-8',
+					env: {
+						...process.env,
+						PI_CODING_AGENT_DIR: agent_dir,
+					},
+				},
+			);
+
+			expect(result.status).toBe(1);
+			expect(result.stdout).toBe('');
+			expect(result.stderr).toBe(
+				'my-pi requires Node >=24.15.0; current version is 24.14.0. Upgrade Node and retry.\n',
+			);
 		} finally {
 			rmSync(agent_dir, { recursive: true, force: true });
 		}

--- a/src/runtime-preflight.test.ts
+++ b/src/runtime-preflight.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+	MINIMUM_NODE_VERSION,
+	get_node_preflight_error,
+	is_supported_node_version,
+} from './runtime-preflight.js';
+
+describe('Node runtime preflight', () => {
+	it('accepts the minimum supported Node version', () => {
+		expect(is_supported_node_version('24.15.0')).toBe(true);
+		expect(get_node_preflight_error('24.15.0')).toBeUndefined();
+	});
+
+	it('rejects the immediately lower Node version', () => {
+		expect(is_supported_node_version('24.14.0')).toBe(false);
+		expect(get_node_preflight_error('24.14.0')).toBe(
+			'my-pi requires Node >=24.15.0; current version is 24.14.0. Upgrade Node and retry.',
+		);
+	});
+
+	it('stays aligned with the package engine requirement', () => {
+		const package_json = JSON.parse(
+			readFileSync('package.json', 'utf-8'),
+		) as { engines?: { node?: string } };
+		expect(package_json.engines?.node).toBe(
+			`>=${MINIMUM_NODE_VERSION}`,
+		);
+	});
+});

--- a/src/runtime-preflight.ts
+++ b/src/runtime-preflight.ts
@@ -1,0 +1,28 @@
+export const MINIMUM_NODE_VERSION = '24.15.0';
+
+function parse_node_version(
+	version: string,
+): [number, number, number] | undefined {
+	const match = /^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
+	if (!match) return undefined;
+	return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function is_supported_node_version(version: string): boolean {
+	const current = parse_node_version(version);
+	const minimum = parse_node_version(MINIMUM_NODE_VERSION);
+	if (!current || !minimum) return false;
+
+	for (let index = 0; index < current.length; index++) {
+		if (current[index] > minimum[index]) return true;
+		if (current[index] < minimum[index]) return false;
+	}
+	return true;
+}
+
+export function get_node_preflight_error(
+	current_version = process.versions.node,
+): string | undefined {
+	if (is_supported_node_version(current_version)) return undefined;
+	return `my-pi requires Node >=${MINIMUM_NODE_VERSION}; current version is ${current_version}. Upgrade Node and retry.`;
+}


### PR DESCRIPTION
## Summary

- fail fast with one actionable error when Node is below `24.15.0`, before built-in extension loading
- cover the supported boundary and below-minimum packed CLI behavior, including exact stderr and non-zero exit
- document deterministic pnpm 11 first-run and recovery commands plus the transitive hook behavior

Closes #353

## Validation

- `pnpm exec vp pack && pnpm exec vp test run src/runtime-preflight.test.ts src/package-smoke.test.ts` — 6 tests passed
- clean pnpm `11.13.1` UAT: `pnpx --allow-build=@google/genai --allow-build=protobufjs my-pi@0.1.115 --help` exited 0 without an approval prompt and ran both known hooks
- `pnpm run check` — formatting, lint, types, package checks, and boundaries passed
- `MY_PI_RUNTIME_MODE=interactive pnpm run test` — root and all package suites passed
- `pnpm install --frozen-lockfile` — passed
- `pnpm changeset status` — patch bump for `my-pi` only
- `pnpm pack --dry-run --json` — CLI, API, and README present
- `git diff --check origin/main...HEAD` — passed
- Changeset word count — 15

## Changeset

> Fail fast on unsupported Node versions and document deterministic pnpm eleven first-run build approval guidance.

## Risks

- Changed-file LSP diagnostics were attempted, but the configured `typescript-language-server` could not initialize against the workspace TypeScript installation. Root lint and type checks passed.
- The upstream `node-domexception` deprecation remains registry/install noise; it does not affect runtime behavior.
