### PR TITLE
feat: standardize command output modal layout

### DIFF
--- a/.changeset/fuzzy-dingos-report.md
+++ b/.changeset/fuzzy-dingos-report.md
@@ -1,0 +1,9 @@
+---
+'@spences10/pi-tui-modal': patch
+'@spences10/pi-lsp': patch
+'@spences10/pi-mcp': patch
+'@spences10/pi-telemetry': patch
+---
+
+Standardize dense command output modals with shared responsive sizing
+across LSP, MCP, and telemetry interfaces.

--- a/packages/pi-lsp/src/commands.ts
+++ b/packages/pi-lsp/src/commands.ts
@@ -3,8 +3,8 @@ import {
 	type ExtensionCommandContext,
 } from '@earendil-works/pi-coding-agent';
 import {
+	show_command_output_modal,
 	show_picker_modal,
-	show_text_modal,
 } from '@spences10/pi-tui-modal';
 import { format_lsp_view, format_status_lines } from './format.js';
 import { LspServerManager } from './server-manager.js';
@@ -187,12 +187,7 @@ async function show_lsp_text_modal(
 	title: string,
 	text: string,
 ): Promise<void> {
-	await show_text_modal(ctx, {
-		title,
-		text,
-		max_visible_lines: 20,
-		overlay_options: { width: '90%', minWidth: 72 },
-	});
+	await show_command_output_modal(ctx, { title, text });
 }
 
 async function handle_lsp_restart_modal(

--- a/packages/pi-mcp/src/ui.ts
+++ b/packages/pi-mcp/src/ui.ts
@@ -1,8 +1,8 @@
 import type { ExtensionCommandContext } from '@earendil-works/pi-coding-agent';
 import {
+	show_command_output_modal,
 	show_picker_modal,
 	show_settings_modal,
-	show_text_modal,
 } from '@spences10/pi-tui-modal';
 import {
 	DISABLED,
@@ -82,12 +82,7 @@ export async function show_mcp_text_modal(
 	title: string,
 	text: string,
 ): Promise<void> {
-	await show_text_modal(ctx, {
-		title,
-		text,
-		max_visible_lines: 20,
-		overlay_options: { width: '90%', minWidth: 72 },
-	});
+	await show_command_output_modal(ctx, { title, text });
 }
 
 export async function show_mcp_server_modal(

--- a/packages/pi-telemetry/src/ui.ts
+++ b/packages/pi-telemetry/src/ui.ts
@@ -1,7 +1,7 @@
 import type { ExtensionCommandContext } from '@earendil-works/pi-coding-agent';
 import {
+	show_command_output_modal,
 	show_picker_modal,
-	show_text_modal,
 } from '@spences10/pi-tui-modal';
 import { resolve } from 'node:path';
 
@@ -17,12 +17,7 @@ export async function show_telemetry_text_modal(
 	title: string,
 	text: string,
 ): Promise<void> {
-	await show_text_modal(ctx, {
-		title,
-		text,
-		max_visible_lines: 20,
-		overlay_options: { width: '90%', minWidth: 72 },
-	});
+	await show_command_output_modal(ctx, { title, text });
 }
 
 export async function show_telemetry_home_modal(

--- a/packages/pi-tui-modal/README.md
+++ b/packages/pi-tui-modal/README.md
@@ -37,6 +37,10 @@ footers remain visible on small terminals.
   Enter/Space to advance; left/right continue to edit an active search
   query when it contains text.
 - `show_text_modal(ctx, options)` — show scrollable read-only output.
+- `show_command_output_modal(ctx, options)` — show dense command or
+  status output with shared wide, responsive defaults. Pass
+  `max_visible_lines` or `overlay_options` to override that policy for
+  a specific report.
 - `show_input_modal(ctx, options)` — collect a single text value with
   IME-safe focus propagation.
 - `show_confirm_modal(ctx, options)` — confirm/cancel destructive or

--- a/packages/pi-tui-modal/src/index.ts
+++ b/packages/pi-tui-modal/src/index.ts
@@ -5,6 +5,7 @@ export type {
 	ProgressModalUpdate,
 } from './modal/progress.js';
 export {
+	show_command_output_modal,
 	show_confirm_modal,
 	show_input_modal,
 	show_modal,

--- a/packages/pi-tui-modal/src/modal/show.test.ts
+++ b/packages/pi-tui-modal/src/modal/show.test.ts
@@ -2,6 +2,7 @@ import type { ExtensionCommandContext } from '@earendil-works/pi-coding-agent';
 import type { Component, TUI } from '@earendil-works/pi-tui';
 import { describe, expect, it, vi } from 'vitest';
 import {
+	show_command_output_modal,
 	show_confirm_modal,
 	show_input_modal,
 	show_modal,
@@ -21,8 +22,13 @@ const theme: ModalTheme = {
 	bold: (text: string) => text,
 };
 
-function create_ctx(result?: unknown, send_input?: string) {
+function create_ctx(
+	result?: unknown,
+	send_input?: string,
+	terminal_rows = 24,
+) {
 	const notify = vi.fn();
+	const rendered_lines: string[] = [];
 	const custom = vi.fn(
 		async (
 			factory: Parameters<ExtensionCommandContext['ui']['custom']>[0],
@@ -33,7 +39,7 @@ function create_ctx(result?: unknown, send_input?: string) {
 			let resolved = result;
 			const component = await factory(
 				{
-					terminal: { rows: 24 },
+					terminal: { rows: terminal_rows },
 					requestRender: vi.fn(),
 				} as unknown as TUI,
 				theme as unknown as CustomFactoryArgs[1],
@@ -43,7 +49,7 @@ function create_ctx(result?: unknown, send_input?: string) {
 				},
 			);
 			(component as Component & { focused: boolean }).focused = true;
-			component.render(80);
+			rendered_lines.push(...component.render(100));
 			if (send_input) component.handleInput?.(send_input);
 			component.dispose?.();
 			return resolved;
@@ -59,6 +65,7 @@ function create_ctx(result?: unknown, send_input?: string) {
 		},
 		custom,
 		notify,
+		rendered_lines,
 	};
 }
 
@@ -111,6 +118,47 @@ describe('show modal helpers', () => {
 		});
 
 		expect(on_change).toHaveBeenCalledWith('alignment', 'right');
+	});
+
+	it('applies overrideable command-output layout defaults', async () => {
+		const defaults = create_ctx(undefined, undefined, 40);
+		await show_command_output_modal(defaults.ctx, {
+			title: 'Output',
+			text: Array.from(
+				{ length: 25 },
+				(_, index) => `line-${index}`,
+			).join('\n'),
+		});
+
+		expect(defaults.custom.mock.calls[0]?.[1]).toMatchObject({
+			overlay: true,
+			overlayOptions: {
+				width: '90%',
+				minWidth: 72,
+			},
+		});
+		expect(
+			defaults.rendered_lines.filter((line) =>
+				line.includes('line-'),
+			),
+		).toHaveLength(20);
+
+		const overrides = create_ctx(undefined, undefined, 40);
+		await show_command_output_modal(overrides.ctx, {
+			title: 'Output',
+			text: 'one\ntwo\nthree',
+			max_visible_lines: 2,
+			overlay_options: { width: '75%', minWidth: 55 },
+		});
+
+		expect(overrides.custom.mock.calls[0]?.[1]).toMatchObject({
+			overlayOptions: { width: '75%', minWidth: 55 },
+		});
+		expect(
+			overrides.rendered_lines.filter((line) =>
+				/one|two|three/.test(line),
+			),
+		).toHaveLength(2);
 	});
 
 	it('wraps picker, text, input, and confirm flows', async () => {

--- a/packages/pi-tui-modal/src/modal/show.ts
+++ b/packages/pi-tui-modal/src/modal/show.ts
@@ -231,6 +231,21 @@ export async function show_text_modal(
 	);
 }
 
+export async function show_command_output_modal(
+	ctx: ModalCommandContext,
+	options: TextModalOptions,
+): Promise<void> {
+	await show_text_modal(ctx, {
+		...options,
+		max_visible_lines: options.max_visible_lines ?? 20,
+		overlay_options: {
+			width: '90%',
+			minWidth: 72,
+			...options.overlay_options,
+		},
+	});
+}
+
 export async function show_input_modal(
 	ctx: ModalCommandContext,
 	options: InputModalOptions,


### PR DESCRIPTION
## Summary

- add `show_command_output_modal` as a semantic, overrideable policy for dense command and status reports
- migrate the exact LSP, MCP, and telemetry duplicates while retaining intentionally different context and observability layouts
- document the public helper and test its defaults, line budget, and caller overrides

A wrapper is justified here because it names and owns a reusable command-output layout policy; a shared object preset would only hide three literals without deepening `pi-tui-modal`.

## Changeset

> Standardize dense command output modals with shared responsive sizing across LSP, MCP, and telemetry interfaces.

Verified as exactly 15 whitespace-separated words. Patch bumps cover `@spences10/pi-tui-modal`, `@spences10/pi-lsp`, `@spences10/pi-mcp`, and `@spences10/pi-telemetry`.

## Validation

- affected package `check`, `test`, and `build` scripts passed
  - pi-tui-modal: 18 tests
  - pi-lsp: 41 tests
  - pi-mcp: 64 tests
  - pi-telemetry: 35 tests
- root `pnpm run check` passed, including boundary validation
- changed-file TypeScript language-server diagnostics: 6 files, 0 diagnostics
- `git diff --check` and harness guard passed
- final diff inspected

The package and root test commands removed the session's inherited `MY_PI_RUNTIME_MODE=print` so pi-mcp's default-interactive lifecycle test ran in its intended environment.

## Risks

No unresolved risks identified. The narrower pi-context layout and wider pi-observability layout remain intentionally distinct because their content-density requirements differ.

Closes #180