### PR TITLE
docs: define pi-footer public API

### DIFF
--- a/.changeset/tidy-footers-report.md
+++ b/.changeset/tidy-footers-report.md
@@ -1,0 +1,6 @@
+---
+'@spences10/pi-footer': patch
+---
+
+Document pi-footer's supported library API and protect published root
+exports with explicit contract test coverage.

--- a/packages/pi-footer/README.md
+++ b/packages/pi-footer/README.md
@@ -15,6 +15,40 @@ It owns `ctx.ui.setFooter(...)` and renders core Pi session data plus
 extension statuses published by other extensions with
 `ctx.ui.setStatus(...)`.
 
+## Library API
+
+`@spences10/pi-footer` is both a Pi extension and a supported library.
+The package root is the only public import path; files under `dist/`
+are implementation details.
+
+```ts
+import footer_extension, {
+	FOOTER_PRESETS,
+	get_current_thinking_level,
+	render_footer_status_line,
+} from '@spences10/pi-footer';
+```
+
+The root API includes:
+
+- the default Pi extension;
+- `get_current_thinking_level` and `get_default_footer_thinking_level`
+  for model-thinking status;
+- `render_footer_lines`, `render_footer_status_line`, and
+  `render_footer_three_column_line` for footer rendering;
+- `FOOTER_PRESETS`, `FOOTER_DENSITIES`, `FOOTER_STATUS_ALIGNMENTS`,
+  `FOOTER_TONES`, `FOOTER_WIDGETS`, plus `FooterPreset`,
+  `FooterDensity`, `FooterStatusAlignment`, `FooterStatusLayout`,
+  `FooterStatusPlacement`, `FooterTone`, and `FooterWidget` for
+  configuration-aware integrations;
+- `FOOTER_COLORS` and `FooterTheme` for theme-compatible rendering;
+- `FOOTER_RESEARCH_REFERENCES`, the reference metadata shown by the
+  `/footer` preset guidance.
+
+These root exports are compatibility-supported. Additive changes can
+ship in minor or patch releases, while removing or changing an export
+requires a breaking release.
+
 ## Commands
 
 - `/footer` — configure layout, density, appearance, visible content,

--- a/packages/pi-footer/src/index.test.ts
+++ b/packages/pi-footer/src/index.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import * as footer from './index.js';
+import type {
+	FooterDensity,
+	FooterPreset,
+	FooterStatusAlignment,
+	FooterStatusLayout,
+	FooterStatusPlacement,
+	FooterTheme,
+	FooterTone,
+	FooterWidget,
+} from './index.js';
+
+const DOCUMENTED_RUNTIME_EXPORTS = [
+	'FOOTER_COLORS',
+	'FOOTER_DENSITIES',
+	'FOOTER_PRESETS',
+	'FOOTER_RESEARCH_REFERENCES',
+	'FOOTER_STATUS_ALIGNMENTS',
+	'FOOTER_TONES',
+	'FOOTER_WIDGETS',
+	'default',
+	'get_current_thinking_level',
+	'get_default_footer_thinking_level',
+	'render_footer_lines',
+	'render_footer_status_line',
+	'render_footer_three_column_line',
+] as const;
+
+describe('@spences10/pi-footer public API', () => {
+	it('keeps the documented runtime exports available from the package root', () => {
+		expect(Object.keys(footer).sort()).toEqual(
+			[...DOCUMENTED_RUNTIME_EXPORTS].sort(),
+		);
+		expect(footer.default).toBeTypeOf('function');
+	});
+
+	it('keeps the documented configuration and theme types available', () => {
+		expectTypeOf<FooterDensity>().toMatchTypeOf<
+			'compact' | 'comfortable' | 'expanded'
+		>();
+		expectTypeOf<FooterPreset>().toMatchTypeOf<
+			'minimal' | 'default' | 'power' | 'git-heavy'
+		>();
+		expectTypeOf<FooterStatusAlignment>().toMatchTypeOf<
+			'left' | 'center' | 'right'
+		>();
+		expectTypeOf<FooterStatusLayout>().toMatchTypeOf<
+			Record<string, FooterStatusPlacement>
+		>();
+		expectTypeOf<FooterTheme>().toHaveProperty('fg');
+		expectTypeOf<FooterTone>().toMatchTypeOf<
+			'muted' | 'balanced' | 'bright'
+		>();
+		expectTypeOf<FooterWidget>().toMatchTypeOf<string>();
+	});
+});


### PR DESCRIPTION
## Summary

- classify `@spences10/pi-footer` as a supported library and Pi extension
- document every supported root runtime export and public type
- add runtime and type-level API contract tests without removing published exports
- add a patch Changeset for the affected publishable package

## Changeset

Exact description (15 whitespace-separated words):

> Document pi-footer's supported library API and protect published root exports with explicit contract test coverage.

## Validation

- `pnpm --filter @spences10/pi-footer run check`
- `pnpm --filter @spences10/pi-footer run test` — 11 files, 28 tests passed
- `pnpm --filter @spences10/pi-footer run build`
- `pnpm run check` — formatting, lint, types, boundaries, and workspace package checks passed
- changed-file LSP diagnostics attempted twice; `typescript-language-server` could not resolve a valid TypeScript installation
- `git diff --cached --check`
- Changeset word count explicitly verified as 15
- final staged diff inspected before commit

## Risks

- LSP diagnostics remain unavailable in this worktree; package and root TypeScript checks passed.
- No published exports were removed, so this remains patch-compatible.

Closes #186
