### PR TITLE
fix(factory): count only eligible calibration outcomes

### DIFF
--- a/.changeset/count-eligible-calibration.md
+++ b/.changeset/count-eligible-calibration.md
@@ -1,0 +1,7 @@
+---
+'@spences10/pi-factory': patch
+'my-pi': patch
+---
+
+Count only complete provenance-verified measured calibration outcomes
+while preserving queryable totals, exclusions, and evidence proposals.

--- a/.changeset/secure-calibration-pins.md
+++ b/.changeset/secure-calibration-pins.md
@@ -1,0 +1,6 @@
+---
+'@spences10/pi-factory': patch
+---
+
+Authenticate factory calibration pins against durable workflow state
+and exclude every mismatched provenance record safely.

--- a/packages/pi-factory/CALIBRATION_BASELINE.md
+++ b/packages/pi-factory/CALIBRATION_BASELINE.md
@@ -25,9 +25,12 @@ pnpm --filter @spences10/pi-factory run test:self -- src/calibration-suite.test.
 A real baseline becomes valid only after `CalibrationSuiteStore`
 imports the configured minimum sample for every workflow from
 authoritative correlated outcomes. Each outcome must carry
-`factory-state` or authenticated-import provenance (never `synthetic`)
-and preserve suite/case/report version, project and policy revision,
-workflow/route/compute/gate pins, explicit evidence-derived label,
+`factory-state` or authenticated-import provenance (never
+`synthetic`). Durable state supplies source/workflow, workspace
+project, policy, route, compute, and gate pins; a named
+embedding-application actor authenticates unavailable suite/case and
+repository revision/shape pins. Outcomes preserve those pins plus
+report version and an explicit evidence-derived label,
 provider/model/reasoning, session, valid duration, measured usage or
 telemetry, every current-contract attempt, and terminal
 validation/review/ approval evidence. Sparse, synthetic, incomplete,

--- a/packages/pi-factory/CALIBRATION_BASELINE.md
+++ b/packages/pi-factory/CALIBRATION_BASELINE.md
@@ -30,9 +30,10 @@ authoritative correlated outcomes. Each outcome must carry
 project, policy, route, compute, and gate pins; a named
 embedding-application actor authenticates unavailable suite/case and
 repository revision/shape pins. Outcomes preserve those pins plus
-report version and an explicit evidence-derived label,
-provider/model/reasoning, session, valid duration, measured usage or
-telemetry, every current-contract attempt, and terminal
-validation/review/ approval evidence. Sparse, synthetic, incomplete,
-contradictory, stale, or incompatible rows remain queryable but block
-baseline promotion and recommendations.
+report version and an explicit evidence-derived label, one consistent
+provider/model/reasoning tuple across every current-contract lifecycle
+event, session, valid duration, measured usage or telemetry, every
+current-contract attempt, and terminal validation/review/ approval
+evidence. Sparse, synthetic, incomplete, contradictory, stale, or
+incompatible rows remain queryable but block baseline promotion and
+recommendations.

--- a/packages/pi-factory/README.md
+++ b/packages/pi-factory/README.md
@@ -205,13 +205,15 @@ from durable factory events; `evaluate_calibration_suite` applies
 configurable sample/confidence/missing-data thresholds and returns
 `baseline_status: "blocked"` until every workflow has sufficient
 complete measured outcomes with exact `factory-state` or
-authenticated-import provenance. Factory outcome imports accept
-measured evidence only when an embedding adapter authenticates the
-suite, case, project, revision, and policy pins and the route, gates,
-and compute pins match durable factory state. Missing or mismatched
-pins remain uncorrelated. `synthetic` provenance is always excluded.
-`CalibrationSuiteStore` persists mode-0600 ledgers and supports
-filtered query plus deterministic JSON export.
+authenticated-import provenance. Factory outcome imports derive the
+source workflow, workspace project id, policy id, route, gates, and
+compute pins from durable state instead of the target case. A named
+embedding-application actor must authenticate the unavailable suite,
+case, repository revision/shape, and policy-hash pins. The complete
+envelope is checked against both durable state and the case; missing
+or mismatched pins remain uncorrelated. `synthetic` provenance is
+always excluded. `CalibrationSuiteStore` persists mode-0600 ledgers
+and supports filtered query plus deterministic JSON export.
 Suite/report/policy/project revisions and fingerprints remain exact;
 findings are marked project-specific unless multiple project ids
 support them. Evaluation exposes eligible `workflow_coverage` plus

--- a/packages/pi-factory/README.md
+++ b/packages/pi-factory/README.md
@@ -217,15 +217,16 @@ and supports filtered query plus deterministic JSON export.
 Suite/report/policy/project revisions and fingerprints remain exact;
 findings are marked project-specific unless multiple project ids
 support them. Evaluation exposes eligible `workflow_coverage` plus
-separate `workflow_total` and `workflow_excluded` counts; evidence
-proposals use eligible coverage only.
-`propose_calibration_experiments` emits reviewable evidence-collection
-or controlled-comparison proposals with `mutates_policy: false`;
-approval/canary rules remain mandatory. Synthetic dogfood is embedded
-only as excluded control-plane evidence. See the explicit
-[baseline status](./CALIBRATION_BASELINE.md)—this repository currently
-claims no real baseline because authorised live correlated evidence is
-unavailable.
+separate `workflow_total` and `workflow_excluded` counts. Eligibility
+requires complete, non-conflicting evidence plus accepted provenance
+and measured correlation; excluded rows cannot reduce evidence
+proposals. `propose_calibration_experiments` emits reviewable
+evidence-collection or controlled-comparison proposals with
+`mutates_policy: false`; approval/canary rules remain mandatory.
+Synthetic dogfood is embedded only as excluded control-plane evidence.
+See the explicit [baseline status](./CALIBRATION_BASELINE.md)—this
+repository currently claims no real baseline because authorised live
+correlated evidence is unavailable.
 
 Versioned `CalibrationCase` and `ObservedOutcome` records pin
 workflow, policy, route, compute, gates, project revision, and cohort

--- a/packages/pi-factory/README.md
+++ b/packages/pi-factory/README.md
@@ -207,13 +207,16 @@ configurable sample/confidence/missing-data thresholds and returns
 complete measured outcomes with exact `factory-state` or
 authenticated-import provenance. Factory outcome imports derive the
 source workflow, workspace project id, policy id, route, gates, and
-compute pins from durable state instead of the target case. A named
-embedding-application actor must authenticate the unavailable suite,
-case, repository revision/shape, and policy-hash pins. The complete
-envelope is checked against both durable state and the case; missing
-or mismatched pins remain uncorrelated. `synthetic` provenance is
-always excluded. `CalibrationSuiteStore` persists mode-0600 ledgers
-and supports filtered query plus deterministic JSON export.
+compute pins from durable state instead of the target case. Every
+current-contract lifecycle event must share one exact
+provider/model/reasoning tuple; mixed planner, executor, reviewer, or
+retry compute remains uncorrelated. A named embedding-application
+actor must authenticate the unavailable suite, case, repository
+revision/shape, and policy-hash pins. The complete envelope is checked
+against both durable state and the case; missing or mismatched pins
+remain uncorrelated. `synthetic` provenance is always excluded.
+`CalibrationSuiteStore` persists mode-0600 ledgers and supports
+filtered query plus deterministic JSON export.
 Suite/report/policy/project revisions and fingerprints remain exact;
 findings are marked project-specific unless multiple project ids
 support them. Evaluation exposes eligible `workflow_coverage` plus
@@ -226,6 +229,10 @@ only as excluded control-plane evidence. See the explicit
 [baseline status](./CALIBRATION_BASELINE.md)—this repository currently
 claims no real baseline because authorised live correlated evidence is
 unavailable.
+
+Legacy import envelopes remain accepted for source compatibility but
+fail closed until they add the named actor and repository-shape fields
+required by embedding-application authentication.
 
 Versioned `CalibrationCase` and `ObservedOutcome` records pin
 workflow, policy, route, compute, gates, project revision, and cohort

--- a/packages/pi-factory/skills/software-factory/SKILL.md
+++ b/packages/pi-factory/skills/software-factory/SKILL.md
@@ -60,8 +60,10 @@ compatibility: Requires Pi with the @spences10/pi-factory extension.
     project/policy/route/compute/gate/retry pins and explicit
     thresholds. Derive available import pins from durable state and
     use named embedding authentication for unavailable pins; never
-    copy target-case values into provenance. Store/query/export the
-    ledger, and keep baseline status blocked until every workflow
-    meets measured coverage. Never generalize a single-project
-    finding.
+    copy target-case values into provenance. Store/query/export total
+    and excluded rows separately, but count only complete,
+    non-conflicting outcomes with accepted provenance and measured
+    correlation toward coverage and evidence proposals. Keep baseline
+    status blocked until every workflow meets eligible coverage. Never
+    generalize a single-project finding.
 14. Finish with `metrics`, validation evidence, and remaining risks.

--- a/packages/pi-factory/skills/software-factory/SKILL.md
+++ b/packages/pi-factory/skills/software-factory/SKILL.md
@@ -58,8 +58,10 @@ compatibility: Requires Pi with the @spences10/pi-factory extension.
     recommendations when calibration reports exclusions.
 13. Define calibration through a versioned suite with exact
     project/policy/route/compute/gate/retry pins and explicit
-    thresholds. Import only authoritative outcomes, store/query/export
-    the ledger, and keep baseline status blocked until every workflow
+    thresholds. Derive available import pins from durable state and
+    use named embedding authentication for unavailable pins; never
+    copy target-case values into provenance. Store/query/export the
+    ledger, and keep baseline status blocked until every workflow
     meets measured coverage. Never generalize a single-project
     finding.
 14. Finish with `metrics`, validation evidence, and remaining risks.

--- a/packages/pi-factory/skills/software-factory/SKILL.md
+++ b/packages/pi-factory/skills/software-factory/SKILL.md
@@ -50,12 +50,12 @@ compatibility: Requires Pi with the @spences10/pi-factory extension.
     use `superseded` or `completed-outside-factory` with explicit
     replacement/external evidence instead of inventing success.
 12. Use comparative metrics only for measured, correlated runs with
-    provider/model/reasoning, session, valid duration, telemetry or
-    usage for every current-contract attempt, matching role/node kind,
-    and one completed non-read-only authoritative attempt per executed
-    node. Hypotheses and retries cannot mask missing correlation.
-    Exclude synthetic or uncorrelated dogfood and refuse
-    recommendations when calibration reports exclusions.
+    one provider/model/reasoning tuple, session, valid duration,
+    telemetry or usage for every current-contract attempt, matching
+    role/node kind, and one completed non-read-only authoritative
+    attempt per executed node. Hypotheses and retries cannot mask
+    missing correlation. Exclude synthetic or uncorrelated dogfood and
+    refuse recommendations when calibration reports exclusions.
 13. Define calibration through a versioned suite with exact
     project/policy/route/compute/gate/retry pins and explicit
     thresholds. Derive available import pins from durable state and

--- a/packages/pi-factory/src/calibration-suite.test.ts
+++ b/packages/pi-factory/src/calibration-suite.test.ts
@@ -9,11 +9,13 @@ import {
 	evaluate_calibration_suite,
 	import_factory_outcome,
 	propose_calibration_experiments,
+	type FactoryOutcomeImportProvenance,
 } from './calibration-suite.js';
 import {
 	create_observed_outcome,
 	type CalibrationCase,
 	type ObservedOutcome,
+	type OutcomeProvenance,
 } from './calibration.js';
 import { dispatch_task } from './dispatch.js';
 import { run_dogfood_baseline } from './dogfood.js';
@@ -100,15 +102,20 @@ function measured_outcomes(
 				workflow_id: `${item.workflow}-${index}`,
 				provenance: {
 					kind: 'authenticated-import',
-					source_id: `${item.case_id}-${index}`,
+					source_id: `${item.workflow}-${index}`,
+					authentication: 'embedding-application',
+					authenticated_actor: 'calibration-test',
 					suite_id: item.suite_id,
 					suite_version: item.suite_version,
 					case_id: item.case_id,
 					case_version: item.case_version,
 					project_id: item.project_id,
 					project_revision: item.project_revision,
+					repository_shape: item.repository_shape,
 					policy_id: item.policy_id,
 					policy_hash: item.policy_hash,
+					workflow: item.workflow,
+					workflow_version: item.workflow_version,
 					route_fingerprint: item.route_fingerprint,
 					compute_fingerprint: item.compute_fingerprint,
 					gate_fingerprint: item.gate_fingerprint,
@@ -309,10 +316,14 @@ describe('versioned calibration suites', () => {
 			classification: 'operator-misuse',
 			evidence_ids: [],
 		});
-		const calibration_case = define_factory_calibration_suite({
+		const calibration_project = {
+			...projects[0]!,
+			project_id: state.route.workspace.id,
+		};
+		const suite = define_factory_calibration_suite({
 			suite_id: 'factory-real-world',
 			suite_version: '1',
-			projects: [projects[0]!],
+			projects: [calibration_project],
 			compute_targets: [
 				{
 					provider: 'provider',
@@ -322,9 +333,13 @@ describe('versioned calibration suites', () => {
 				},
 			],
 			dogfood: run_dogfood_baseline(policy, process.cwd()),
-		}).cases.find((item) => item.workflow === 'feature')!;
-		const authenticated = {
-			authenticated: true as const,
+		});
+		const calibration_case = suite.cases.find(
+			(item) => item.workflow === 'feature',
+		)!;
+		const authenticated: FactoryOutcomeImportProvenance = {
+			authentication: 'embedding-application',
+			authenticated_actor: 'calibration-test',
 			source_id: state.workflow_id,
 			suite_id: calibration_case.suite_id!,
 			suite_version: calibration_case.suite_version!,
@@ -332,6 +347,7 @@ describe('versioned calibration suites', () => {
 			case_version: calibration_case.case_version,
 			project_id: calibration_case.project_id!,
 			project_revision: calibration_case.project_revision,
+			repository_shape: calibration_case.repository_shape,
 			policy_id: calibration_case.policy_id,
 			policy_hash: calibration_case.policy_hash,
 		};
@@ -348,26 +364,75 @@ describe('versioned calibration suites', () => {
 				status: 'measured',
 				terminal_outcome: 'failed',
 			},
+			provenance: {
+				kind: 'authenticated-import',
+				source_id: state.workflow_id,
+				project_id: state.route.workspace.id,
+				policy_id: state.route.policy_id,
+				workflow: state.route.workflow.id,
+				workflow_version: state.route.workflow.version,
+			},
 		});
-		const incompatible_imports = [
-			[calibration_case, undefined],
+		expect(
+			evaluate_calibration_suite(suite, [imported]).workflow_coverage
+				.feature,
+		).toBe(1);
+
+		const incompatible_imports: Array<
 			[
+				string,
+				CalibrationCase,
+				FactoryOutcomeImportProvenance | undefined,
+			]
+		> = [
+			['missing authentication', calibration_case, undefined],
+			[
+				'authentication actor',
+				calibration_case,
+				{ ...authenticated, authenticated_actor: ' ' },
+			],
+			[
+				'factory source',
+				calibration_case,
+				{ ...authenticated, source_id: 'forged-workflow' },
+			],
+			[
+				'project identity',
+				{ ...calibration_case, project_id: 'forged-project' },
+				authenticated,
+			],
+			[
+				'project revision',
 				calibration_case,
 				{ ...authenticated, project_revision: 'forged-revision' },
 			],
 			[
+				'project shape',
+				calibration_case,
+				{ ...authenticated, repository_shape: 'forged-shape' },
+			],
+			[
+				'policy identity',
+				{ ...calibration_case, policy_id: 'forged-policy@1' },
+				authenticated,
+			],
+			[
+				'policy hash',
 				calibration_case,
 				{ ...authenticated, policy_hash: 'forged-policy' },
 			],
 			[
+				'route',
 				{ ...calibration_case, route_fingerprint: 'forged-route' },
 				authenticated,
 			],
 			[
+				'gates',
 				{ ...calibration_case, gate_fingerprint: 'forged-gates' },
 				authenticated,
 			],
 			[
+				'compute fingerprint',
 				{
 					...calibration_case,
 					compute_fingerprint: 'forged-compute',
@@ -375,18 +440,111 @@ describe('versioned calibration suites', () => {
 				authenticated,
 			],
 			[
+				'compute model',
+				{ ...calibration_case, model: 'forged-model' },
+				authenticated,
+			],
+			[
+				'suite identity',
+				calibration_case,
+				{ ...authenticated, suite_id: 'forged-suite' },
+			],
+			[
+				'suite version',
 				calibration_case,
 				{ ...authenticated, suite_version: 'forged-suite' },
 			],
 			[
+				'case identity',
 				calibration_case,
 				{ ...authenticated, case_id: 'forged-case' },
 			],
-		] as const;
-		for (const [target, provenance] of incompatible_imports)
-			expect(
-				import_factory_outcome(state, target, provenance),
-			).toMatchObject({ correlation: { status: 'uncorrelated' } });
+			[
+				'case version',
+				calibration_case,
+				{ ...authenticated, case_version: 'forged-case' },
+			],
+			[
+				'workflow identity',
+				{ ...calibration_case, workflow: 'chore' },
+				authenticated,
+			],
+			[
+				'workflow version',
+				{ ...calibration_case, workflow_version: 'forged-workflow' },
+				authenticated,
+			],
+		];
+		const rejected = incompatible_imports.map(
+			([name, target, provenance]) => {
+				const outcome = import_factory_outcome(
+					state,
+					target,
+					provenance,
+				);
+				expect(outcome.correlation?.status, name).toBe(
+					'uncorrelated',
+				);
+				expect(
+					outcome.evidence.every((item) => !item.complete),
+					name,
+				).toBe(true);
+				expect(outcome.provenance, name).toMatchObject({
+					source_id: state.workflow_id,
+					project_id: state.route.workspace.id,
+					policy_id: state.route.policy_id,
+					workflow: state.route.workflow.id,
+					workflow_version: state.route.workflow.version,
+					gate_fingerprint: imported.provenance?.gate_fingerprint,
+					compute_fingerprint:
+						imported.provenance?.compute_fingerprint,
+				});
+				return outcome;
+			},
+		);
+		const rejected_evaluation = evaluate_calibration_suite(
+			suite,
+			rejected,
+		);
+		expect(rejected_evaluation.workflow_total.feature).toBe(
+			incompatible_imports.length,
+		);
+		expect(rejected_evaluation.workflow_coverage.feature).toBe(0);
+		expect(rejected_evaluation.workflow_excluded.feature).toBe(
+			incompatible_imports.length,
+		);
+
+		const persisted_pin_attacks: Array<
+			[string, Partial<OutcomeProvenance>]
+		> = [
+			['authentication', { authenticated_actor: ' ' }],
+			['source', { source_id: 'forged-workflow' }],
+			['project', { project_id: 'forged-project' }],
+			['policy', { policy_hash: 'forged-policy' }],
+			['route', { route_fingerprint: 'forged-route' }],
+			['gates', { gate_fingerprint: 'forged-gates' }],
+			['compute', { compute_fingerprint: 'forged-compute' }],
+			['suite', { suite_id: 'forged-suite' }],
+			['case', { case_id: 'forged-case' }],
+			['workflow', { workflow_version: 'forged-workflow' }],
+		];
+		const tampered = persisted_pin_attacks.map(
+			([name, forged], index) => {
+				const outcome = structuredClone(imported);
+				outcome.outcome_id = `${imported.outcome_id}-${index}`;
+				Object.assign(outcome.provenance!, forged);
+				expect(outcome.correlation?.status, name).toBe('measured');
+				return outcome;
+			},
+		);
+		const tampered_evaluation = evaluate_calibration_suite(
+			suite,
+			tampered,
+		);
+		expect(tampered_evaluation.workflow_coverage.feature).toBe(0);
+		expect(tampered_evaluation.workflow_excluded.feature).toBe(
+			persisted_pin_attacks.length,
+		);
 
 		const incomplete = create_factory_state(route, 'owner');
 		expect(

--- a/packages/pi-factory/src/calibration-suite.test.ts
+++ b/packages/pi-factory/src/calibration-suite.test.ts
@@ -559,7 +559,7 @@ describe('versioned calibration suites', () => {
 		});
 	});
 
-	it('excludes ineligible rows from coverage and evidence proposals', () => {
+	it('keeps threshold-sized excluded datasets out of coverage and evidence proposals', () => {
 		const suite = create_calibration_suite({
 			suite_id: 'factory-real-world',
 			suite_version: '1',
@@ -573,20 +573,65 @@ describe('versioned calibration suites', () => {
 			},
 			dogfood: run_dogfood_baseline(policy, process.cwd()),
 		});
-		const outcomes = measured_outcomes(suite.cases);
-		for (const outcome of outcomes.filter(
-			(item) => item.case_id === 'feature-case',
-		))
-			outcome.provenance!.kind = 'synthetic';
-		const evaluation = evaluate_calibration_suite(suite, outcomes);
-		expect(evaluation.workflow_total.feature).toBe(2);
-		expect(evaluation.workflow_coverage.feature).toBe(0);
-		expect(evaluation.workflow_excluded.feature).toBe(2);
-		const proposal = propose_calibration_experiments(
-			suite,
-			evaluation,
-		).find((item) => item.workflow === 'feature');
-		expect(proposal?.rationale).toContain('Collect 2 additional');
+		const excluded_datasets: Array<{
+			name: string;
+			exclude: (outcome: ObservedOutcome) => void;
+		}> = [
+			{
+				name: 'synthetic provenance',
+				exclude: (outcome) => {
+					outcome.provenance!.kind = 'synthetic';
+				},
+			},
+			{
+				name: 'incompatible provenance',
+				exclude: (outcome) => {
+					outcome.provenance!.policy_hash = 'incompatible-policy';
+				},
+			},
+			{
+				name: 'uncorrelated measurement',
+				exclude: (outcome) => {
+					outcome.correlation!.status = 'uncorrelated';
+				},
+			},
+			{
+				name: 'incomplete evidence',
+				exclude: (outcome) => {
+					outcome.evidence[0]!.complete = false;
+					outcome.label = 'incomplete';
+				},
+			},
+			{
+				name: 'conflicting evidence',
+				exclude: (outcome) => {
+					outcome.evidence[0]!.contradictory = true;
+					outcome.label = 'conflicting-evidence';
+				},
+			},
+		];
+		for (const dataset of excluded_datasets) {
+			const outcomes = measured_outcomes(suite.cases);
+			for (const outcome of outcomes.filter(
+				(item) => item.case_id === 'feature-case',
+			))
+				dataset.exclude(outcome);
+			const evaluation = evaluate_calibration_suite(suite, outcomes);
+			expect(evaluation.workflow_total.feature, dataset.name).toBe(2);
+			expect(evaluation.workflow_coverage.feature, dataset.name).toBe(
+				0,
+			);
+			expect(evaluation.workflow_excluded.feature, dataset.name).toBe(
+				2,
+			);
+			const proposal = propose_calibration_experiments(
+				suite,
+				evaluation,
+			).find((item) => item.workflow === 'feature');
+			expect(proposal?.rationale, dataset.name).toContain(
+				'Collect 2 additional',
+			);
+		}
 	});
 
 	it('stores, queries, and exports exact suite/report/project revisions', () => {

--- a/packages/pi-factory/src/calibration-suite.test.ts
+++ b/packages/pi-factory/src/calibration-suite.test.ts
@@ -9,6 +9,7 @@ import {
 	evaluate_calibration_suite,
 	import_factory_outcome,
 	propose_calibration_experiments,
+	type AuthenticatedFactoryOutcomeImportProvenance,
 	type FactoryOutcomeImportProvenance,
 } from './calibration-suite.js';
 import {
@@ -337,20 +338,21 @@ describe('versioned calibration suites', () => {
 		const calibration_case = suite.cases.find(
 			(item) => item.workflow === 'feature',
 		)!;
-		const authenticated: FactoryOutcomeImportProvenance = {
-			authentication: 'embedding-application',
-			authenticated_actor: 'calibration-test',
-			source_id: state.workflow_id,
-			suite_id: calibration_case.suite_id!,
-			suite_version: calibration_case.suite_version!,
-			case_id: calibration_case.case_id,
-			case_version: calibration_case.case_version,
-			project_id: calibration_case.project_id!,
-			project_revision: calibration_case.project_revision,
-			repository_shape: calibration_case.repository_shape,
-			policy_id: calibration_case.policy_id,
-			policy_hash: calibration_case.policy_hash,
-		};
+		const authenticated: AuthenticatedFactoryOutcomeImportProvenance =
+			{
+				authentication: 'embedding-application',
+				authenticated_actor: 'calibration-test',
+				source_id: state.workflow_id,
+				suite_id: calibration_case.suite_id!,
+				suite_version: calibration_case.suite_version!,
+				case_id: calibration_case.case_id,
+				case_version: calibration_case.case_version,
+				project_id: calibration_case.project_id!,
+				project_revision: calibration_case.project_revision,
+				repository_shape: calibration_case.repository_shape,
+				policy_id: calibration_case.policy_id,
+				policy_hash: calibration_case.policy_hash,
+			};
 		const imported = import_factory_outcome(
 			state,
 			calibration_case,
@@ -377,6 +379,71 @@ describe('versioned calibration suites', () => {
 			evaluate_calibration_suite(suite, [imported]).workflow_coverage
 				.feature,
 		).toBe(1);
+
+		const legacy: FactoryOutcomeImportProvenance = {
+			authenticated: true,
+			source_id: state.workflow_id,
+			suite_id: calibration_case.suite_id!,
+			suite_version: calibration_case.suite_version!,
+			case_id: calibration_case.case_id,
+			case_version: calibration_case.case_version,
+			project_id: calibration_case.project_id!,
+			project_revision: calibration_case.project_revision,
+			policy_id: calibration_case.policy_id,
+			policy_hash: calibration_case.policy_hash,
+		};
+		const legacy_imported = import_factory_outcome(
+			state,
+			calibration_case,
+			legacy,
+		);
+		expect(legacy_imported).toMatchObject({
+			correlation: { status: 'uncorrelated' },
+			provenance: {
+				kind: 'authenticated-import',
+				authentication: undefined,
+				authenticated_actor: undefined,
+				repository_shape: undefined,
+			},
+		});
+
+		const execution_event = state.events.find(
+			(event) => event.id === 'execution',
+		)!;
+		const mixed_compute_attacks = [
+			['provider', 'forged-provider'],
+			['model', 'forged-model'],
+			['reasoning', 'forged-reasoning'],
+		] as const;
+		for (const [field, value] of mixed_compute_attacks) {
+			const mixed_state = structuredClone(state);
+			mixed_state.events.push({
+				...execution_event,
+				id: `mixed-${field}`,
+				tokens: 13,
+				metadata: {
+					...execution_event.metadata,
+					execution_id: `mixed-${field}`,
+					[field]: value,
+				},
+			});
+			const mixed_import = import_factory_outcome(
+				mixed_state,
+				calibration_case,
+				authenticated,
+			);
+			expect(mixed_import.correlation, field).toMatchObject({
+				status: 'uncorrelated',
+				provider: 'provider',
+				model: 'model',
+				reasoning: 'high',
+			});
+			expect(mixed_import.tokens, field).toBe(25);
+			expect(
+				mixed_import.evidence.every((item) => !item.complete),
+				field,
+			).toBe(true);
+		}
 
 		const incompatible_imports: Array<
 			[

--- a/packages/pi-factory/src/calibration-suite.ts
+++ b/packages/pi-factory/src/calibration-suite.ts
@@ -223,9 +223,14 @@ export function create_calibration_suite(input: {
 }
 
 export interface FactoryOutcomeImportProvenance {
+	/**
+	 * @deprecated Add authentication, authenticated_actor, and
+	 * repository_shape. Legacy envelopes remain accepted but fail closed.
+	 */
+	authenticated?: true;
 	/** The embedding application authenticated this complete pin envelope. */
-	authentication: 'embedding-application';
-	authenticated_actor: string;
+	authentication?: 'embedding-application';
+	authenticated_actor?: string;
 	source_id: string;
 	suite_id: string;
 	suite_version: string;
@@ -233,9 +238,15 @@ export interface FactoryOutcomeImportProvenance {
 	case_version: string;
 	project_id: string;
 	project_revision: string;
-	repository_shape: string;
+	repository_shape?: string;
 	policy_id: string;
 	policy_hash: string;
+}
+
+export interface AuthenticatedFactoryOutcomeImportProvenance extends FactoryOutcomeImportProvenance {
+	authentication: 'embedding-application';
+	authenticated_actor: string;
+	repository_shape: string;
 }
 
 const failure_label: Record<string, OutcomeLabel> = {
@@ -273,6 +284,12 @@ export function import_factory_outcome(
 	const reasoning = correlation_event?.metadata?.reasoning as
 		| string
 		| undefined;
+	const consistent_compute = lifecycle.every(
+		(event) =>
+			event.metadata?.provider === provider &&
+			event.metadata?.model === model &&
+			event.metadata?.reasoning === reasoning,
+	);
 	const authenticated_pins = Boolean(
 		provenance?.authentication === 'embedding-application' &&
 		typeof provenance.authenticated_actor === 'string' &&
@@ -327,7 +344,10 @@ export function import_factory_outcome(
 				...state.route.workflow.nodes.map((node) => node.retry_limit),
 			);
 	const complete_correlation =
-		durable_correlation && authenticated_pins && durable_pins;
+		durable_correlation &&
+		consistent_compute &&
+		authenticated_pins &&
+		durable_pins;
 	const evidence: OutcomeEvidence[] = [];
 	for (const event of state.events.filter(
 		(item) => item.type === 'failure.classified',

--- a/packages/pi-factory/src/calibration-suite.ts
+++ b/packages/pi-factory/src/calibration-suite.ts
@@ -193,6 +193,7 @@ export function create_calibration_suite(input: {
 				calibration_case.repository_shape ||
 			project.project_revision !==
 				calibration_case.project_revision ||
+			project.policy_id !== calibration_case.policy_id ||
 			project.policy_hash !== calibration_case.policy_hash
 		)
 			throw new Error(
@@ -222,8 +223,9 @@ export function create_calibration_suite(input: {
 }
 
 export interface FactoryOutcomeImportProvenance {
-	/** The embedding adapter has authenticated these pins. */
-	authenticated: true;
+	/** The embedding application authenticated this complete pin envelope. */
+	authentication: 'embedding-application';
+	authenticated_actor: string;
 	source_id: string;
 	suite_id: string;
 	suite_version: string;
@@ -231,6 +233,7 @@ export interface FactoryOutcomeImportProvenance {
 	case_version: string;
 	project_id: string;
 	project_revision: string;
+	repository_shape: string;
 	policy_id: string;
 	policy_hash: string;
 }
@@ -271,16 +274,22 @@ export function import_factory_outcome(
 		| string
 		| undefined;
 	const authenticated_pins = Boolean(
-		provenance?.authenticated &&
-		provenance.source_id &&
+		provenance?.authentication === 'embedding-application' &&
+		typeof provenance.authenticated_actor === 'string' &&
+		provenance.authenticated_actor.trim() &&
+		provenance.source_id === state.workflow_id &&
 		provenance.suite_id === calibration_case.suite_id &&
 		provenance.suite_version === calibration_case.suite_version &&
 		provenance.case_id === calibration_case.case_id &&
 		provenance.case_version === calibration_case.case_version &&
 		provenance.project_id === calibration_case.project_id &&
+		provenance.project_id === state.route.workspace.id &&
 		provenance.project_revision ===
 			calibration_case.project_revision &&
+		provenance.repository_shape ===
+			calibration_case.repository_shape &&
 		provenance.policy_id === calibration_case.policy_id &&
+		provenance.policy_id === state.route.policy_id &&
 		provenance.policy_hash === calibration_case.policy_hash,
 	);
 	const route_pin = sha({
@@ -289,6 +298,7 @@ export function import_factory_outcome(
 		project_revision: provenance?.project_revision,
 		policy_hash: provenance?.policy_hash,
 	});
+	const gate_pin = sha(state.route.workflow.validations);
 	const compute_pin = sha({
 		provider,
 		model,
@@ -296,14 +306,14 @@ export function import_factory_outcome(
 		parallelism: state.route.workflow.compute.parallelism,
 	});
 	const durable_pins =
+		calibration_case.project_id === state.route.workspace.id &&
 		calibration_case.workflow === state.route.workflow.id &&
 		calibration_case.workflow_version ===
 			state.route.workflow.version &&
 		calibration_case.policy_id === state.route.policy_id &&
 		calibration_case.risk === state.route.workflow.risk &&
 		calibration_case.route_fingerprint === route_pin &&
-		calibration_case.gate_fingerprint ===
-			sha(state.route.workflow.validations) &&
+		calibration_case.gate_fingerprint === gate_pin &&
 		calibration_case.compute_fingerprint === compute_pin &&
 		calibration_case.provider === provider &&
 		calibration_case.model === model &&
@@ -364,26 +374,26 @@ export function import_factory_outcome(
 		});
 	return create_observed_outcome({
 		case_id: calibration_case.case_id,
-		provenance: provenance
-			? {
-					kind: 'authenticated-import',
-					source_id: provenance.source_id,
-					suite_id: provenance.suite_id,
-					suite_version: provenance.suite_version,
-					case_id: provenance.case_id,
-					case_version: provenance.case_version,
-					project_id: provenance.project_id,
-					project_revision: provenance.project_revision,
-					policy_id: provenance.policy_id,
-					policy_hash: provenance.policy_hash,
-					route_fingerprint: route_pin,
-					compute_fingerprint: compute_pin,
-					gate_fingerprint: sha(state.route.workflow.validations),
-				}
-			: {
-					kind: 'factory-state',
-					source_id: state.workflow_id,
-				},
+		provenance: {
+			kind: provenance ? 'authenticated-import' : 'factory-state',
+			source_id: state.workflow_id,
+			authentication: provenance?.authentication,
+			authenticated_actor: provenance?.authenticated_actor,
+			suite_id: provenance?.suite_id,
+			suite_version: provenance?.suite_version,
+			case_id: provenance?.case_id,
+			case_version: provenance?.case_version,
+			project_id: state.route.workspace.id,
+			project_revision: provenance?.project_revision,
+			repository_shape: provenance?.repository_shape,
+			policy_id: state.route.policy_id,
+			policy_hash: provenance?.policy_hash,
+			workflow: state.route.workflow.id,
+			workflow_version: state.route.workflow.version,
+			route_fingerprint: route_pin,
+			compute_fingerprint: compute_pin,
+			gate_fingerprint: gate_pin,
+		},
 		case_version: calibration_case.case_version,
 		workflow_id: state.workflow_id,
 		evidence,
@@ -450,6 +460,10 @@ export function evaluate_calibration_suite(
 			!calibration_case ||
 			!provenance ||
 			provenance.kind === 'synthetic' ||
+			provenance.source_id !== outcome.workflow_id ||
+			(provenance.kind === 'authenticated-import' &&
+				(provenance.authentication !== 'embedding-application' ||
+					!provenance.authenticated_actor?.trim())) ||
 			provenance.suite_id !== suite.suite_id ||
 			provenance.suite_version !== suite.suite_version ||
 			provenance.case_id !== calibration_case.case_id ||
@@ -457,8 +471,13 @@ export function evaluate_calibration_suite(
 			provenance.project_id !== calibration_case.project_id ||
 			provenance.project_revision !==
 				calibration_case.project_revision ||
+			provenance.repository_shape !==
+				calibration_case.repository_shape ||
 			provenance.policy_id !== calibration_case.policy_id ||
 			provenance.policy_hash !== calibration_case.policy_hash ||
+			provenance.workflow !== calibration_case.workflow ||
+			provenance.workflow_version !==
+				calibration_case.workflow_version ||
 			provenance.route_fingerprint !==
 				calibration_case.route_fingerprint ||
 			provenance.compute_fingerprint !==

--- a/packages/pi-factory/src/calibration-suite.ts
+++ b/packages/pi-factory/src/calibration-suite.ts
@@ -447,6 +447,15 @@ export function import_factory_outcome(
 	});
 }
 
+function is_eligible_measured_outcome(
+	outcome: ObservedOutcome,
+): boolean {
+	return (
+		is_comparable_outcome(outcome) &&
+		!['incomplete', 'conflicting-evidence'].includes(outcome.label)
+	);
+}
+
 export function evaluate_calibration_suite(
 	suite: CalibrationSuite,
 	outcomes: ObservedOutcome[],
@@ -519,7 +528,7 @@ export function evaluate_calibration_suite(
 			workflow,
 			reviewed_outcomes.filter(
 				(outcome) =>
-					is_comparable_outcome(outcome) &&
+					is_eligible_measured_outcome(outcome) &&
 					suite.cases.some(
 						(item) =>
 							item.case_id === outcome.case_id &&

--- a/packages/pi-factory/src/calibration.ts
+++ b/packages/pi-factory/src/calibration.ts
@@ -74,14 +74,19 @@ export interface OutcomeCorrelation {
 export interface OutcomeProvenance {
 	kind: 'factory-state' | 'authenticated-import' | 'synthetic';
 	source_id: string;
+	authentication?: 'embedding-application';
+	authenticated_actor?: string;
 	suite_id?: string;
 	suite_version?: string;
 	case_id?: string;
 	case_version?: string;
 	project_id?: string;
 	project_revision?: string;
+	repository_shape?: string;
 	policy_id?: string;
 	policy_hash?: string;
+	workflow?: WorkflowKind;
+	workflow_version?: string;
 	route_fingerprint?: string;
 	compute_fingerprint?: string;
 	gate_fingerprint?: string;

--- a/packages/pi-factory/src/index.ts
+++ b/packages/pi-factory/src/index.ts
@@ -11,6 +11,7 @@ export type {
 	CalibrationProject,
 	CalibrationSuite,
 	CalibrationSuiteEvaluation,
+	AuthenticatedFactoryOutcomeImportProvenance,
 	FactoryOutcomeImportProvenance,
 	ProposedCalibrationExperiment,
 } from './calibration-suite.js';


### PR DESCRIPTION
## Summary

- count only complete, non-conflicting, comparable measured outcomes accepted by suite provenance and correlation checks toward workflow coverage
- retain separately queryable per-workflow total and excluded counts, and derive evidence proposals only from eligible coverage
- cover threshold-sized synthetic, incompatible, uncorrelated, incomplete, and conflicting datasets without reducing missing-evidence proposals

Fixes #355

## Stack dependency

Depends on PR #389. This branch is stacked on PR #389 but targets `main`; merge #389 first for a focused final diff.

## Validation

- real harness `issue-355-eligible-calibration-mrsb177c` validation and guard passed
- `pnpm --filter @spences10/pi-factory run check:self`
- `pnpm --filter @spences10/pi-factory run test:self` — 149 tests passed
- `pnpm --filter @spences10/pi-factory run build`
- `pnpm run check` — formatting, lint/types, boundaries, and all package checks passed
- `pnpx check-skills validate packages/pi-factory/skills/software-factory --json`
- `pnpm changeset status` — patch bumps resolved for `@spences10/pi-factory` and `my-pi`
- explicit normalized Changeset description equality and whitespace word-count assertion — 15 words
- changed-file LSP diagnostics invoked for both TypeScript files; `typescript-language-server` could not initialize against the workspace TypeScript installation, while package and root TypeScript checks passed
- `git diff --check` and staged final-diff inspection passed

## Changeset

Exact description (15 whitespace-separated words):

> Count only complete provenance-verified measured calibration outcomes while preserving queryable totals, exclusions, and evidence proposals.

## Risks

- This PR depends on the provenance authentication changes in PR #389 and must not merge before its base.
- Changed-file LSP diagnostics remain unavailable in this workspace; TypeScript validation passed through package and root checks.
- Root boundary validation reports 15 existing large-source advisories, including calibration modules; the boundary check passed.