### PR TITLE
docs: clarify upstream UI primitive boundaries

### DIFF
--- a/.changeset/honest-pi-primitives.md
+++ b/.changeset/honest-pi-primitives.md
@@ -1,0 +1,8 @@
+---
+'@spences10/pi-footer': patch
+'@spences10/pi-themes': patch
+'@spences10/pi-tui-modal': patch
+---
+
+Clarify how footer, theme, and modal packages compose upstream Pi
+primitives while preserving curated behavior.

--- a/packages/pi-footer/README.md
+++ b/packages/pi-footer/README.md
@@ -17,11 +17,14 @@ runtime signals so long agent sessions stay easy to orient and trust.
 
 ## Upstream Pi boundary
 
-Pi owns the footer lifecycle and status transport through
-`ctx.ui.setFooter(...)`, `ctx.ui.setStatus(...)`, and the footer data
-provider. This package uses those APIs directly; it does not replace
-or re-export them. Without the curated layouts below, Pi's built-in
-footer already renders core session data and extension statuses.
+Pi owns the footer lifecycle through `ctx.ui.setFooter(...)` and
+status transport through `ctx.ui.setStatus(...)` plus the footer data
+provider. This package directly calls `setFooter` and reads the data
+provider; it does not call, wrap, or re-export `setStatus`. Other
+extensions publish status values through `setStatus`, and Pi supplies
+them to this renderer through the provider. Without the curated
+layouts below, Pi's built-in footer already renders core session data
+and extension statuses.
 
 `pi-footer` adds the configurable part: presets, density and tone,
 selectable widgets, multi-row status placement, persistent settings,

--- a/packages/pi-footer/README.md
+++ b/packages/pi-footer/README.md
@@ -15,9 +15,19 @@ See the session state that matters without leaving Pi. `pi-footer`
 adds a configurable statusline for model, project, Git, token, and
 runtime signals so long agent sessions stay easy to orient and trust.
 
-It owns `ctx.ui.setFooter(...)` and renders core Pi session data plus
-extension statuses published by other extensions with
-`ctx.ui.setStatus(...)`.
+## Upstream Pi boundary
+
+Pi owns the footer lifecycle and status transport through
+`ctx.ui.setFooter(...)`, `ctx.ui.setStatus(...)`, and the footer data
+provider. This package uses those APIs directly; it does not replace
+or re-export them. Without the curated layouts below, Pi's built-in
+footer already renders core session data and extension statuses.
+
+`pi-footer` adds the configurable part: presets, density and tone,
+selectable widgets, multi-row status placement, persistent settings,
+and the `/footer` live-preview workflow. Installing it replaces Pi's
+built-in footer renderer with that curated UI while continuing to read
+status values published through Pi's native API.
 
 ## Library API
 

--- a/packages/pi-themes/README.md
+++ b/packages/pi-themes/README.md
@@ -35,10 +35,12 @@ JSON:
 
 ## Upstream Pi boundary
 
-Pi natively discovers, validates, selects, and hot-reloads themes.
-This package contains only curated theme JSON and declares its
-`themes/` directory through the native `pi.themes` package manifest;
-it ships no extension or theme-loading wrapper.
+Pi natively discovers, validates, and selects package themes. Hot
+reload applies only to Pi's watched active custom-theme file in the
+global theme directory, not to theme assets resolved from an installed
+package. This package contains only curated theme JSON and declares
+its `themes/` directory through the native `pi.themes` package
+manifest; it ships no extension or theme-loading wrapper.
 
 Use Pi's global or project theme directories for a single personal
 theme. Install this package when you want its maintained collection of

--- a/packages/pi-themes/README.md
+++ b/packages/pi-themes/README.md
@@ -33,6 +33,17 @@ JSON:
 }
 ```
 
+## Upstream Pi boundary
+
+Pi natively discovers, validates, selects, and hot-reloads themes.
+This package contains only curated theme JSON and declares its
+`themes/` directory through the native `pi.themes` package manifest;
+it ships no extension or theme-loading wrapper.
+
+Use Pi's global or project theme directories for a single personal
+theme. Install this package when you want its maintained collection of
+coordinated palettes as one native Pi package.
+
 ## Included themes
 
 - Catppuccin Mocha

--- a/packages/pi-tui-modal/README.md
+++ b/packages/pi-tui-modal/README.md
@@ -16,6 +16,21 @@ Build Pi overlays that feel consistent instead of one-off.
 settings, prompts, confirmations, and scrollable text views used
 across Pi extensions.
 
+## Upstream Pi boundary
+
+Pi already provides `ctx.ui.select(...)`, `ctx.ui.confirm(...)`, and
+`ctx.ui.input(...)` for simple dialogs. It also owns custom-component
+and overlay lifecycles through `ctx.ui.custom(...)` and
+`overlayOptions`, while `@earendil-works/pi-tui` supplies components
+such as `SelectList` and `SettingsList`.
+
+Use those upstream APIs directly when their default UI is sufficient.
+This package does not re-export or replace them. Its helpers compose
+them into the shared my-pi experience: consistent modal chrome,
+responsive terminal-height budgets, focus propagation, searchable
+settings with metadata, scrollable text, and dense command-output
+defaults.
+
 ## Styling
 
 Modals render with a full rounded border by default. Pass `style` to


### PR DESCRIPTION
## Summary

- source-verified Pi v0.80.10 and current upstream main (`13437ca`) for footer/status, theme/package, and custom overlay primitives
- documented that `pi-footer` composes native footer/status APIs with curated rendering, presets, persistence, and status placement
- documented that `pi-themes` is curated static content loaded through native `pi.themes` packaging
- directed simple dialogs to Pi's built-ins while retaining `pi-tui-modal` for reusable responsive, framed, searchable overlays
- added patch Changesets for all three packages; prose is explicitly verified as exactly fifteen whitespace-separated words

No runtime wrapper removal was justified: the current source composes upstream primitives and adds scoped behavior rather than mirroring their APIs. Public exports remain compatible.

## Validation

- `pnpm --filter @spences10/pi-footer run check`
- `pnpm --filter @spences10/pi-footer run test` — 11 files, 28 tests passed
- `pnpm --filter @spences10/pi-footer run build`
- `pnpm --filter @spences10/pi-themes run check`
- `pnpm --filter @spences10/pi-themes run test`
- `pnpm --filter @spences10/pi-themes run build`
- `pnpm --filter @spences10/pi-tui-modal run check`
- `pnpm --filter @spences10/pi-tui-modal run test` — 6 files, 18 tests passed
- `pnpm --filter @spences10/pi-tui-modal run build`
- `pnpm run check`
- `pnpm changeset status`
- explicit Changeset whitespace-word assertion — 15 words
- `git diff --check`
- final staged diff inspection
- changed-file LSP attempted; no Markdown language server is configured, and no TypeScript/Svelte files changed

## Remaining risks

- Markdown-specific LSP diagnostics were unavailable; repository formatting and Markdown-link validation passed.
- Root validation reports 15 non-blocking large-file architecture advisories; they remain open.

Closes #294