### PR TITLE
feat(pi-observability): add opt-in provider session attribution

### DIFF
--- a/.changeset/calm-gateways-observe.md
+++ b/.changeset/calm-gateways-observe.md
@@ -1,0 +1,6 @@
+---
+'@spences10/pi-observability': patch
+---
+
+Add opt-in provider session attribution headers while keeping
+observability identifiers private by default across requests.

--- a/.changeset/calm-gateways-observe.md
+++ b/.changeset/calm-gateways-observe.md
@@ -2,5 +2,5 @@
 '@spences10/pi-observability': patch
 ---
 
-Add opt-in provider session attribution headers while keeping
-observability identifiers private by default across requests.
+Add opt-in generic provider session attribution headers while
+documenting Pi's existing default OpenCode attribution behavior.

--- a/packages/pi-observability/README.md
+++ b/packages/pi-observability/README.md
@@ -69,8 +69,13 @@ MY_PI_OBSERVABILITY_RETENTION_DAYS=14
 MY_PI_OBSERVABILITY_MAX_EVENTS=100000
 MY_PI_OBSERVABILITY_MAX_BODY_BYTES=1048576
 MY_PI_OBSERVABILITY_DETAIL=detailed # detailed or summary
-MY_PI_OBSERVABILITY_FORWARD_SESSION_ID=true # opt-in provider attribution
 MY_PI_OBSERVABILITY_TOKEN=dev-token
+```
+
+Agent process environment variable:
+
+```bash
+MY_PI_OBSERVABILITY_FORWARD_SESSION_ID=true # opt-in provider attribution
 ```
 
 The local API requires bearer authentication by default. On first
@@ -114,7 +119,8 @@ MY_PI_OBSERVABILITY_TAG=agent-a,experiment-1 \
 pi
 ```
 
-Equivalent Pi flags:
+Equivalent extension flags when this package is loaded by vanilla
+upstream `pi` (the `my-pi` wrapper does not forward extension flags):
 
 ```text
 --observability-url
@@ -155,15 +161,20 @@ Raw payload mode is opt-in with `--observability-raw` or
 `MY_PI_OBSERVABILITY_RAW=true`; redaction and a payload byte cap still
 apply.
 
-Provider session attribution is separately disabled by default and
-requires Pi 0.80.4 or newer. Enable
-`--observability-forward-session-id` or set
-`MY_PI_OBSERVABILITY_FORWARD_SESSION_ID=true` to add the stable local
-Pi session identifier as `x-pi-session-id` on every outgoing provider
-request. This shares that identifier with the selected provider or
-gateway, so enable it only for endpoints you trust. The observability
-bearer token, pool, tags, and event payloads are never added to
-provider headers.
+This extension's generic `x-pi-session-id` attribution header is
+disabled by default and requires Pi 0.80.4 or newer. With vanilla
+upstream `pi`, enable `--observability-forward-session-id`. With the
+`my-pi` executable, set `MY_PI_OBSERVABILITY_FORWARD_SESSION_ID=true`
+on the agent process, not only on a separately launched observability
+server. Either option adds the stable local Pi session identifier to
+every outgoing provider request, so enable it only for endpoints you
+trust. The observability bearer token, pool, tags, and event payloads
+are never added to provider headers.
+
+This setting controls only the extension's generic header. Pinned Pi
+0.80.10 independently sends the same stable identifier as
+`x-opencode-session`, plus `x-opencode-client: pi`, by default for
+OpenCode, OpenCode Go, and requests to an OpenCode host.
 
 The dashboard shell and static assets are public on the configured
 listener, but event ingestion, queries, trace data, and live streams

--- a/packages/pi-observability/README.md
+++ b/packages/pi-observability/README.md
@@ -69,6 +69,7 @@ MY_PI_OBSERVABILITY_RETENTION_DAYS=14
 MY_PI_OBSERVABILITY_MAX_EVENTS=100000
 MY_PI_OBSERVABILITY_MAX_BODY_BYTES=1048576
 MY_PI_OBSERVABILITY_DETAIL=detailed # detailed or summary
+MY_PI_OBSERVABILITY_FORWARD_SESSION_ID=true # opt-in provider attribution
 MY_PI_OBSERVABILITY_TOKEN=dev-token
 ```
 
@@ -123,6 +124,7 @@ Equivalent Pi flags:
 --observability-name
 --observability-raw
 --observability-detail
+--observability-forward-session-id
 --observability-disable
 --no-observability
 ```
@@ -152,6 +154,16 @@ Set `MY_PI_OBSERVABILITY_DETAIL=summary` or
 Raw payload mode is opt-in with `--observability-raw` or
 `MY_PI_OBSERVABILITY_RAW=true`; redaction and a payload byte cap still
 apply.
+
+Provider session attribution is separately disabled by default and
+requires Pi 0.80.4 or newer. Enable
+`--observability-forward-session-id` or set
+`MY_PI_OBSERVABILITY_FORWARD_SESSION_ID=true` to add the stable local
+Pi session identifier as `x-pi-session-id` on every outgoing provider
+request. This shares that identifier with the selected provider or
+gateway, so enable it only for endpoints you trust. The observability
+bearer token, pool, tags, and event payloads are never added to
+provider headers.
 
 The dashboard shell and static assets are public on the configured
 listener, but event ingestion, queries, trace data, and live streams

--- a/packages/pi-observability/src/index.test.ts
+++ b/packages/pi-observability/src/index.test.ts
@@ -14,6 +14,8 @@ import type { ObservabilityEvent } from './types.js';
 
 function observability_harness(options?: {
 	configured_name?: string;
+	configured_token?: string;
+	forward_session_id?: boolean;
 	session_name?: string;
 }) {
 	const handlers = new Map<
@@ -34,6 +36,12 @@ function observability_harness(options?: {
 		['observability-url', 'http://observability.test'],
 		...(options?.configured_name
 			? ([['observability-name', options.configured_name]] as const)
+			: []),
+		...(options?.configured_token
+			? ([['observability-token', options.configured_token]] as const)
+			: []),
+		...(options?.forward_session_id
+			? ([['observability-forward-session-id', true]] as const)
 			: []),
 	]);
 	const pi = {
@@ -93,6 +101,7 @@ describe('resolve_observability_config', () => {
 		expect(config).toMatchObject({
 			server_url: 'http://127.0.0.1:43190',
 			auto_start_server: true,
+			forward_session_id: false,
 		});
 		expect(config?.token).toHaveLength(43);
 	});
@@ -130,6 +139,7 @@ describe('resolve_observability_config', () => {
 			{
 				MY_PI_OBSERVABILITY_POOL: 'test',
 				MY_PI_OBSERVABILITY_DETAIL: 'summary',
+				MY_PI_OBSERVABILITY_FORWARD_SESSION_ID: 'true',
 			},
 		);
 		expect(config).toMatchObject({
@@ -137,6 +147,7 @@ describe('resolve_observability_config', () => {
 			pool: 'test',
 			tags: ['one', 'two'],
 			detail_level: 'summary',
+			forward_session_id: true,
 			auto_start_server: false,
 		});
 	});
@@ -205,6 +216,51 @@ describe('resolve_observability_config', () => {
 			vi.unstubAllEnvs();
 			rmSync(agent_dir, { recursive: true, force: true });
 		}
+	});
+});
+
+describe('provider session attribution', () => {
+	it('does not change provider headers by default', async () => {
+		const harness = observability_harness();
+		const headers = {
+			authorization: 'Bearer provider-secret',
+			'x-existing': 'keep',
+		};
+
+		await harness.trigger('session_start');
+		await harness.trigger('before_provider_headers', { headers });
+		await harness.trigger('session_shutdown');
+
+		expect(headers).toEqual({
+			authorization: 'Bearer provider-secret',
+			'x-existing': 'keep',
+		});
+		harness.fetch_mock.mockRestore();
+	});
+
+	it('adds only the session id header when explicitly enabled', async () => {
+		const harness = observability_harness({
+			configured_token: 'observability-secret',
+			forward_session_id: true,
+		});
+		const headers = {
+			authorization: 'Bearer provider-secret',
+			'x-existing': 'keep',
+		};
+
+		await harness.trigger('session_start');
+		await harness.trigger('before_provider_headers', { headers });
+		await harness.trigger('session_shutdown');
+
+		expect(headers).toEqual({
+			authorization: 'Bearer provider-secret',
+			'x-existing': 'keep',
+			'x-pi-session-id': 'session-1',
+		});
+		expect(Object.values(headers)).not.toContain(
+			'observability-secret',
+		);
+		harness.fetch_mock.mockRestore();
 	});
 });
 

--- a/packages/pi-observability/src/index.ts
+++ b/packages/pi-observability/src/index.ts
@@ -98,6 +98,9 @@ export function resolve_observability_config(
 		raw_payloads:
 			as_boolean(pi.getFlag('observability-raw')) ||
 			as_boolean(env.MY_PI_OBSERVABILITY_RAW),
+		forward_session_id:
+			as_boolean(pi.getFlag('observability-forward-session-id')) ||
+			as_boolean(env.MY_PI_OBSERVABILITY_FORWARD_SESSION_ID),
 		detail_level: detail_level(
 			pi.getFlag('observability-detail') ??
 				env.MY_PI_OBSERVABILITY_DETAIL,
@@ -462,6 +465,11 @@ export default function observability(pi: ExtensionAPI) {
 		type: 'string',
 		default: undefined,
 	});
+	pi.registerFlag('observability-forward-session-id', {
+		description: 'Add x-pi-session-id to outgoing provider requests',
+		type: 'boolean',
+		default: false,
+	});
 	pi.registerFlag('observability-disable', {
 		description: 'Disable live observability for this process',
 		type: 'boolean',
@@ -584,6 +592,12 @@ export default function observability(pi: ExtensionAPI) {
 	observe('after_provider_response', 'provider_response');
 	observe('session_compact', 'compaction');
 	observe('session_tree', 'branch_nav');
+
+	pi.on('before_provider_headers', (event, ctx) => {
+		if (!config?.forward_session_id) return;
+		event.headers['x-pi-session-id'] =
+			ctx.sessionManager.getSessionId();
+	});
 
 	pi.on('session_info_changed', async (event, ctx) => {
 		if (session)

--- a/packages/pi-observability/src/index.ts
+++ b/packages/pi-observability/src/index.ts
@@ -30,6 +30,10 @@ const DEFAULT_BATCH_SIZE = 50;
 const DEFAULT_MAX_QUEUE_SIZE = 10_000;
 export const DEFAULT_OBSERVABILITY_URL = 'http://127.0.0.1:43190';
 
+interface ResolvedObservabilityConfig extends ObservabilityConfig {
+	forward_session_id: boolean;
+}
+
 function as_string(value: unknown): string | undefined {
 	return typeof value === 'string' && value.length > 0
 		? value
@@ -60,7 +64,7 @@ export function parse_tags(value: unknown): string[] {
 export function resolve_observability_config(
 	pi: Pick<ExtensionAPI, 'getFlag'>,
 	env: NodeJS.ProcessEnv = process.env,
-): ObservabilityConfig | null {
+): ResolvedObservabilityConfig | null {
 	if (as_boolean(pi.getFlag('observability-disable'))) return null;
 	if (as_boolean(env.MY_PI_OBSERVABILITY_DISABLE)) return null;
 
@@ -528,7 +532,7 @@ export default function observability(pi: ExtensionAPI) {
 		},
 	});
 
-	let config: ObservabilityConfig | null = null;
+	let config: ResolvedObservabilityConfig | null = null;
 	let queue: EventQueue | null = null;
 	let session: SessionInfo | null = null;
 	let seq = 0;

--- a/packages/pi-observability/src/index.ts
+++ b/packages/pi-observability/src/index.ts
@@ -30,10 +30,6 @@ const DEFAULT_BATCH_SIZE = 50;
 const DEFAULT_MAX_QUEUE_SIZE = 10_000;
 export const DEFAULT_OBSERVABILITY_URL = 'http://127.0.0.1:43190';
 
-interface ResolvedObservabilityConfig extends ObservabilityConfig {
-	forward_session_id: boolean;
-}
-
 function as_string(value: unknown): string | undefined {
 	return typeof value === 'string' && value.length > 0
 		? value
@@ -64,7 +60,7 @@ export function parse_tags(value: unknown): string[] {
 export function resolve_observability_config(
 	pi: Pick<ExtensionAPI, 'getFlag'>,
 	env: NodeJS.ProcessEnv = process.env,
-): ResolvedObservabilityConfig | null {
+): ObservabilityConfig | null {
 	if (as_boolean(pi.getFlag('observability-disable'))) return null;
 	if (as_boolean(env.MY_PI_OBSERVABILITY_DISABLE)) return null;
 
@@ -532,7 +528,7 @@ export default function observability(pi: ExtensionAPI) {
 		},
 	});
 
-	let config: ResolvedObservabilityConfig | null = null;
+	let config: ObservabilityConfig | null = null;
 	let queue: EventQueue | null = null;
 	let session: SessionInfo | null = null;
 	let seq = 0;

--- a/packages/pi-observability/src/types.test.ts
+++ b/packages/pi-observability/src/types.test.ts
@@ -1,0 +1,20 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { ObservabilityConfig } from './index.js';
+
+describe('public observability types', () => {
+	it('accepts configuration objects from before session forwarding', () => {
+		const legacy_config: ObservabilityConfig = {
+			server_url: 'http://127.0.0.1:43190',
+			pool: 'default',
+			tags: [],
+			raw_payloads: false,
+			detail_level: 'detailed',
+			max_payload_bytes: 32_768,
+			auto_start_server: true,
+		};
+
+		expectTypeOf<
+			typeof legacy_config
+		>().toExtend<ObservabilityConfig>();
+	});
+});

--- a/packages/pi-observability/src/types.test.ts
+++ b/packages/pi-observability/src/types.test.ts
@@ -1,4 +1,6 @@
-import { describe, expectTypeOf, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import type { ObservabilityConfig } from './index.js';
 
 describe('public observability types', () => {
@@ -16,5 +18,23 @@ describe('public observability types', () => {
 		expectTypeOf<
 			typeof legacy_config
 		>().toExtend<ObservabilityConfig>();
+	});
+
+	it('emits downstream compatibility declarations', () => {
+		const tsc = fileURLToPath(
+			new URL(
+				'../node_modules/typescript/lib/tsc.js',
+				import.meta.url,
+			),
+		);
+		const project = fileURLToPath(
+			new URL('../tsconfig.compatibility.json', import.meta.url),
+		);
+
+		expect(() =>
+			execFileSync(process.execPath, [tsc, '--project', project], {
+				stdio: 'pipe',
+			}),
+		).not.toThrow();
 	});
 });

--- a/packages/pi-observability/src/types.test.ts
+++ b/packages/pi-observability/src/types.test.ts
@@ -36,5 +36,5 @@ describe('public observability types', () => {
 				stdio: 'pipe',
 			}),
 		).not.toThrow();
-	});
+	}, 30_000);
 });

--- a/packages/pi-observability/src/types.ts
+++ b/packages/pi-observability/src/types.ts
@@ -106,6 +106,7 @@ export interface ObservabilityConfig {
 	tags: string[];
 	agent_name?: string;
 	raw_payloads: boolean;
+	forward_session_id: boolean;
 	detail_level: 'summary' | 'detailed';
 	max_payload_bytes: number;
 	auto_start_server: boolean;

--- a/packages/pi-observability/src/types.ts
+++ b/packages/pi-observability/src/types.ts
@@ -106,7 +106,7 @@ export interface ObservabilityConfig {
 	tags: string[];
 	agent_name?: string;
 	raw_payloads: boolean;
-	forward_session_id: boolean;
+	forward_session_id?: boolean;
 	detail_level: 'summary' | 'detailed';
 	max_payload_bytes: number;
 	auto_start_server: boolean;

--- a/packages/pi-observability/test/compatibility/declaration-emit.ts
+++ b/packages/pi-observability/test/compatibility/declaration-emit.ts
@@ -1,0 +1,7 @@
+import { resolve_observability_config } from '../../src/index.js';
+
+export function downstream_config(
+	pi: Parameters<typeof resolve_observability_config>[0],
+) {
+	return resolve_observability_config(pi);
+}

--- a/packages/pi-observability/test/compatibility/resolver-mock.ts
+++ b/packages/pi-observability/test/compatibility/resolver-mock.ts
@@ -1,0 +1,17 @@
+import {
+	resolve_observability_config,
+	type ObservabilityConfig,
+} from '../../src/index.js';
+
+const legacy_config: ObservabilityConfig = {
+	server_url: 'http://127.0.0.1:43190',
+	pool: 'default',
+	tags: [],
+	raw_payloads: false,
+	detail_level: 'detailed',
+	max_payload_bytes: 32_768,
+	auto_start_server: true,
+};
+
+export const legacy_resolver: typeof resolve_observability_config =
+	() => legacy_config;

--- a/packages/pi-observability/tsconfig.compatibility.json
+++ b/packages/pi-observability/tsconfig.compatibility.json
@@ -1,0 +1,12 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"declaration": true,
+		"emitDeclarationOnly": true,
+		"outDir": "./node_modules/.cache/type-compatibility",
+		"rootDir": ".",
+		"types": ["node"]
+	},
+	"include": ["test/compatibility/**/*.ts"],
+	"exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- use Pi's pinned `before_provider_headers` hook instead of adding provider-specific request plumbing
- add separately opt-in `x-pi-session-id` forwarding to `@spences10/pi-observability`
- keep telemetry local-only and preserve all provider headers by default
- document the privacy boundary and Pi 0.80.4+ requirement
- add a patch Changeset whose prose is exactly 15 words

## Decision evidence

Pinned Pi 0.80.10 exports and dispatches `before_provider_headers`; upstream added it in 0.80.4 via earendil-works/pi#6350. Observability owns gateway/session correlation, while telemetry promises local SQLite metrics, so telemetry does not gain outbound identifier behavior.

## Validation

- `pnpm --filter @spences10/pi-observability run check`
- `pnpm --filter @spences10/pi-observability run test` — 14 files, 71 tests passed
- `pnpm --filter @spences10/pi-observability run build`
- `pnpm --filter @spences10/pi-observability exec tsc --project tsconfig.compatibility.json` — resolver-mock and downstream declaration-emit fixtures passed
- generated declaration inspection — `resolve_observability_config` remains `ObservabilityConfig | null` with no private resolved type
- `pnpm run check` — formatting, lint/types, docs, package checks, and boundaries passed
- `pnpm run build`
- `MY_PI_RUNTIME_MODE=interactive pnpm run test` — root 37 files/151 tests and all package suites passed; observability 14/71
- `pnpm changeset status` — observability patch plus dependent root patch
- changed-file LSP diagnostics — 6 files clean, 0 diagnostics
- `git diff --check`
- Changeset prose word count — exactly 15
- exact-head GitHub Actions CI, Semgrep, and Workers checks passed

## Remaining risks

- Attribution requires Pi 0.80.4+ and a gateway that accepts `x-pi-session-id`.
- Enabling the option intentionally shares a stable local session identifier with the selected provider.
- Root boundary validation still reports the observability entrypoint as a 623-line maintainability advisory.

Closes #290