### PR TITLE
docs(skills): clarify upstream value add

### DIFF
--- a/.changeset/bright-skills-boundaries.md
+++ b/.changeset/bright-skills-boundaries.md
@@ -1,0 +1,8 @@
+---
+'@spences10/pi-skill-importer': patch
+'@spences10/pi-skills': patch
+---
+
+Clarify how skills packages complement upstream discovery,
+configuration, imports, profiles, provenance, and GitHub lifecycle
+management.

--- a/packages/pi-skill-importer/README.md
+++ b/packages/pi-skill-importer/README.md
@@ -12,8 +12,34 @@
 <!-- package-readme:header:end -->
 
 Move external Agent Skills into Pi without hand-copying files.
-`pi-skill-importer` provides the import helpers Pi uses to normalize
-skill metadata, content, and storage from compatible skill sources.
+`pi-skill-importer` provides provenance-aware helpers for copying and
+maintaining skills from compatible external sources.
+
+## Relationship to upstream Pi
+
+Audit baseline: upstream Pi
+[`0.80.10`](https://github.com/earendil-works/pi/tree/13437ca828894f43f973c630d208b488637d8fa9/packages/coding-agent)
+can load other harnesses' skill directories directly through the
+`skills` settings array or `--skill`; copying is not required merely
+to make those skills available. Pi also owns Agent Skills parsing,
+validation, discovery, and native storage loading. This package is for
+users who intentionally want independently managed Pi-native copies.
+
+| Capability                                                                         | Classification     | Boundary and remaining value                                                                                                 |
+| ---------------------------------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| Loading external skill files or directories through settings or `--skill`          | Upstream primitive | Point Pi at `~/.claude/skills` or another compatible directory when a copied snapshot is unnecessary.                        |
+| Loading copied skills from `$PI_CODING_AGENT_DIR/skills`                           | Wrapper            | The importer writes into Pi's native skill location; Pi performs discovery and execution.                                    |
+| Claude installed-plugin cache discovery                                            | Additive feature   | Finds skills and plugin version/commit context that Pi does not import or track.                                             |
+| Provenance metadata, content hashes, safe sync/rebind, and metadata-owned deletion | Additive feature   | Tracks copied snapshots, refuses to overwrite local edits, recovers moved plugin caches, and never deletes upstream sources. |
+| Public import/sync/delete API and consolidated `/skills` integration               | Additive feature   | Supports custom management flows and the preferred `pi-skills` UI.                                                           |
+| Copying solely to make an external directory loadable                              | Removal candidate  | Use Pi's native `skills` setting instead; import only when copy ownership and provenance are required.                       |
+| Standalone `/skill-importer` command                                               | Removal candidate  | Kept as a deprecated compatibility surface while `/skills` is the preferred UI.                                              |
+
+See upstream's
+[Skills](https://github.com/earendil-works/pi/blob/13437ca828894f43f973c630d208b488637d8fa9/packages/coding-agent/docs/skills.md)
+and
+[settings](https://github.com/earendil-works/pi/blob/13437ca828894f43f973c630d208b488637d8fa9/packages/coding-agent/docs/settings.md#resources)
+for the native no-copy path.
 
 The public API powers the consolidated `/skills` → **Add / import**
 experience. The extension still registers `/skill-importer` with

--- a/packages/pi-skills/README.md
+++ b/packages/pi-skills/README.md
@@ -35,10 +35,38 @@ pi install ./packages/pi-skills
 pi -e ./packages/pi-skills
 ```
 
+## Relationship to upstream Pi
+
+Audit baseline: upstream Pi
+[`0.80.10`](https://github.com/earendil-works/pi/tree/13437ca828894f43f973c630d208b488637d8fa9/packages/coding-agent)
+already implements the Agent Skills runtime, including parsing and
+validation, prompt exposure, `/skill:name`, trusted project discovery,
+package-managed skills, settings and CLI paths, and per-resource
+selection through `pi config`. Its SDK also exposes skill loading,
+`resources_discover`, and `skillsOverride`. This package does not
+replace those primitives.
+
+| Capability                                                                                                      | Classification     | Boundary and remaining value                                                                               |
+| --------------------------------------------------------------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------- |
+| Agent Skills parsing, validation, prompt exposure, and `/skill:name`                                            | Upstream primitive | Pi owns skill semantics and execution.                                                                     |
+| Global, trusted project, package, settings, and CLI skill discovery                                             | Upstream primitive | Prefer Pi's documented locations and package manifest support.                                             |
+| Static per-resource enable/disable through `pi config`                                                          | Upstream primitive | Use native configuration when profiles and context switching are unnecessary.                              |
+| Scanning native skill metadata and contributing selected paths through `resources_discover` or `skillsOverride` | Wrapper            | Supplies the package UI and profile decisions while Pi remains the loader.                                 |
+| GitHub search, preview, install, and update                                                                     | Wrapper            | Delegates source tracking and updates to the preview `gh skill` commands; this is not a Pi SDK feature.    |
+| Named profiles, inherited pattern rules, and `cwd`/GitHub context selection                                     | Additive feature   | Provides reusable skill sets and automatic project-aware activation beyond native static filters.          |
+| Consolidated management UI and importer composition                                                             | Additive feature   | Combines profile operations, GitHub lifecycle actions, and provenance-aware external imports in `/skills`. |
+| Discovery of `SKILL.md` below `.agents/**` outside `.agents/skills/`                                            | Removal candidate  | Retained for compatibility; new skills should use Pi's native `.agents/skills/` layout.                    |
+
+See upstream's
+[Skills](https://github.com/earendil-works/pi/blob/13437ca828894f43f973c630d208b488637d8fa9/packages/coding-agent/docs/skills.md),
+[Pi Packages](https://github.com/earendil-works/pi/blob/13437ca828894f43f973c630d208b488637d8fa9/packages/coding-agent/docs/packages.md),
+and
+[extension resource events](https://github.com/earendil-works/pi/blob/13437ca828894f43f973c630d208b488637d8fa9/packages/coding-agent/docs/extensions.md#resources_discover)
+for the native behavior this package composes.
+
 ## What it does
 
-Pi already has native skill discovery. This package adds a management
-layer for Pi skill ecosystems:
+This package adds a management layer around Pi's native skill runtime:
 
 - discovers Pi-native skills in `$PI_CODING_AGENT_DIR/skills`
   (default: `~/.pi/agent/skills`)


### PR DESCRIPTION
## Summary

- source-verifies upstream Agent Skills primitives against Pi 0.80.10 at `13437ca828894f43f973c630d208b488637d8fa9`
- classifies each `pi-skills` and `pi-skill-importer` capability as an upstream primitive, wrapper, additive feature, or removal candidate
- clarifies the remaining value of profiles, context selection, GitHub lifecycle management, Claude plugin provenance, safe sync/rebind, and owned deletion
- retains compatibility behavior because the evidence did not justify implementation or API removals
- adds patch Changesets for both affected publishable packages with an explicitly verified fifteen-word description

## Classification outcome

- **Upstream primitives:** Agent Skills parsing/validation, prompt and `/skill:name` exposure, native locations, package/settings/CLI discovery, direct external-directory loading, and `pi config` resource toggles
- **Wrappers:** native metadata/path filtering through `resources_discover`/`skillsOverride`, native storage loading, and preview `gh skill` lifecycle commands
- **Additive features:** profiles and context rules, consolidated management, Claude installed-plugin discovery, provenance, hash-protected sync/rebind, and metadata-owned deletion
- **Removal candidates:** nonstandard `.agents/**` compatibility discovery, copy-only loading use cases, and deprecated `/skill-importer`

## Validation

- `pnpm --filter @spences10/pi-skill-importer run check` — passed
- `pnpm --filter @spences10/pi-skill-importer run test` — passed (3 files, 13 tests)
- `pnpm --filter @spences10/pi-skill-importer run build` — passed
- `pnpm --filter @spences10/pi-skills run check` — passed
- `pnpm --filter @spences10/pi-skills run test` — passed (17 files, 66 tests)
- `pnpm --filter @spences10/pi-skills run build` — passed
- `pnpm run check` — passed; boundary scan reported 15 architecture advisories and no blocking errors
- changed-file `lsp_diagnostics_many` — attempted; no Markdown language server is configured, and no TypeScript/Svelte source changed
- `git diff --check` — passed
- Changeset prose word-count script — passed with exactly 15 whitespace-separated words
- final staged diff and harness guard — inspected and passed

## Remaining risks

- GitHub CLI still marks `gh skill` as preview, so its wrapper contract may change.
- Removal candidates remain supported until migration and usage evidence justifies a breaking cleanup.
- Markdown files had no configured LSP; formatting and link checks passed through root validation.

Closes #293
