### PR TITLE
refactor trust wrapper mechanics

### DIFF
--- a/.changeset/generic-trust-wrappers.md
+++ b/.changeset/generic-trust-wrappers.md
@@ -1,0 +1,10 @@
+---
+'@spences10/pi-project-trust': patch
+'@spences10/pi-factory': patch
+'@spences10/pi-mcp': patch
+'@spences10/pi-lsp': patch
+'my-pi': patch
+---
+
+Share generic project trust wrappers while preserving MCP, LSP, and
+hooks legacy trust migration behavior.

--- a/packages/pi-lsp/src/trust.ts
+++ b/packages/pi-lsp/src/trust.ts
@@ -1,16 +1,22 @@
-import { getAgentDir } from '@earendil-works/pi-coding-agent';
 import {
-	is_project_subject_trusted,
-	read_project_trust_store,
-	trust_project_subject,
+	create_project_trust_wrapper,
 	type ProjectTrustSubject,
 } from '@spences10/pi-project-trust';
-import { join } from 'node:path';
 
 const LSP_PROJECT_BINARY_ENV = 'MY_PI_LSP_PROJECT_BINARY';
 
+const lsp_binary_trust = create_project_trust_wrapper({
+	store_filename: 'trusted-lsp-binaries.json',
+	legacy_matcher: (entry, subject) => {
+		const legacy_entry = entry as
+			| { binary_path?: unknown }
+			| undefined;
+		return legacy_entry?.binary_path === subject.id;
+	},
+});
+
 export function default_lsp_trust_store_path(): string {
-	return join(getAgentDir(), 'trusted-lsp-binaries.json');
+	return lsp_binary_trust.default_trust_store_path();
 }
 
 export function create_lsp_binary_trust_subject(
@@ -35,21 +41,17 @@ export function is_lsp_binary_trusted(
 	binary_path: string,
 	trust_store_path = default_lsp_trust_store_path(),
 ): boolean {
-	const subject = create_lsp_binary_trust_subject(binary_path);
-	if (is_project_subject_trusted(subject, trust_store_path))
-		return true;
-
-	const entry = read_project_trust_store(trust_store_path)[
-		binary_path
-	] as { binary_path?: unknown } | undefined;
-	return entry?.binary_path === binary_path;
+	return lsp_binary_trust.is_trusted(
+		create_lsp_binary_trust_subject(binary_path),
+		trust_store_path,
+	);
 }
 
 export function trust_lsp_binary(
 	binary_path: string,
 	trust_store_path = default_lsp_trust_store_path(),
 ): void {
-	trust_project_subject(
+	lsp_binary_trust.trust(
 		create_lsp_binary_trust_subject(binary_path),
 		trust_store_path,
 	);

--- a/packages/pi-mcp/src/trust.ts
+++ b/packages/pi-mcp/src/trust.ts
@@ -1,16 +1,25 @@
-import { getAgentDir } from '@earendil-works/pi-coding-agent';
 import {
-	is_project_subject_trusted,
-	read_project_trust_store,
-	trust_project_subject,
+	create_project_trust_wrapper,
 	type ProjectTrustSubject,
 } from '@spences10/pi-project-trust';
-import { join } from 'node:path';
 
 const MCP_PROJECT_CONFIG_ENV = 'MY_PI_MCP_PROJECT_CONFIG';
 
+const mcp_project_trust = create_project_trust_wrapper({
+	store_filename: 'trusted-mcp-projects.json',
+	legacy_matcher: (entry, subject) => {
+		const legacy_entry = entry as
+			| { path?: unknown; hash?: unknown }
+			| undefined;
+		return (
+			legacy_entry?.path === subject.id &&
+			legacy_entry.hash === subject.hash
+		);
+	},
+});
+
 export function default_mcp_trust_store_path(): string {
-	return join(getAgentDir(), 'trusted-mcp-projects.json');
+	return mcp_project_trust.default_trust_store_path();
 }
 
 export function create_mcp_project_trust_subject(
@@ -33,14 +42,10 @@ export function is_project_mcp_config_trusted(
 	hash: string,
 	trust_store_path = default_mcp_trust_store_path(),
 ): boolean {
-	const subject = create_mcp_project_trust_subject(path, hash);
-	if (is_project_subject_trusted(subject, trust_store_path))
-		return true;
-
-	const legacy_entry = read_project_trust_store(trust_store_path)[
-		path
-	] as { path?: string; hash?: string } | undefined;
-	return legacy_entry?.path === path && legacy_entry.hash === hash;
+	return mcp_project_trust.is_trusted(
+		create_mcp_project_trust_subject(path, hash),
+		trust_store_path,
+	);
 }
 
 export function trust_project_mcp_config(
@@ -48,7 +53,7 @@ export function trust_project_mcp_config(
 	hash: string,
 	trust_store_path = default_mcp_trust_store_path(),
 ): void {
-	trust_project_subject(
+	mcp_project_trust.trust(
 		create_mcp_project_trust_subject(path, hash),
 		trust_store_path,
 	);

--- a/packages/pi-project-trust/README.md
+++ b/packages/pi-project-trust/README.md
@@ -43,6 +43,28 @@ const decision = await resolve_project_trust(
 );
 ```
 
+## Reusable trust wrappers
+
+Use `create_project_trust_wrapper()` when several subject-specific
+functions need the same store handling. The wrapper constructs the
+store path, checks current entries, optionally checks a legacy entry,
+and delegates persistence. Kinds, ids, hashes, environment keys,
+prompt copy, fallbacks, and choice labels remain in the caller.
+
+```ts
+import { create_project_trust_wrapper } from '@spences10/pi-project-trust';
+
+const project_config_trust = create_project_trust_wrapper({
+	store_filename: 'trusted-example-projects.json',
+	legacy_matcher: (entry, subject) => {
+		const legacy = entry as { path?: unknown; hash?: unknown };
+		return (
+			legacy?.path === subject.id && legacy.hash === subject.hash
+		);
+	},
+});
+```
+
 ## Decisions
 
 Environment values are normalized consistently across extensions:

--- a/packages/pi-project-trust/src/index.test.ts
+++ b/packages/pi-project-trust/src/index.test.ts
@@ -6,7 +6,7 @@ import {
 	writeFileSync,
 } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join, relative, sep } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
 	apply_project_trust_untrusted_defaults,
@@ -147,6 +147,36 @@ describe('create_project_trust_wrapper', () => {
 			join(homedir(), 'trusted-example.json'),
 		);
 	});
+
+	it.each([
+		[
+			'plain',
+			'file:///tmp/pi-agent',
+			join('/tmp/pi-agent', 'trusted-example-projects.json'),
+		],
+		[
+			'percent-encoded',
+			'file:///tmp/pi%20agent',
+			join('/tmp/pi agent', 'trusted-example-projects.json'),
+		],
+	])(
+		'normalizes %s file URL agent directories outside cwd',
+		(_label, agent_dir, expected) => {
+			const wrapper = create_project_trust_wrapper({
+				store_filename: 'trusted-example-projects.json',
+			});
+			process.env.PI_CODING_AGENT_DIR = agent_dir;
+
+			const store = wrapper.default_trust_store_path();
+			expect(store).toBe(expected);
+			expect(isAbsolute(store)).toBe(true);
+			const relative_to_cwd = relative(process.cwd(), store);
+			expect(
+				relative_to_cwd === '..' ||
+					relative_to_cwd.startsWith(`..${sep}`),
+			).toBe(true);
+		},
+	);
 
 	it('delegates current trust matching and persistence', () => {
 		const store = trust_store_path();

--- a/packages/pi-project-trust/src/index.test.ts
+++ b/packages/pi-project-trust/src/index.test.ts
@@ -5,11 +5,12 @@ import {
 	statSync,
 	writeFileSync,
 } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
 	apply_project_trust_untrusted_defaults,
+	create_project_trust_wrapper,
 	default_project_trust_store_path,
 	is_project_subject_trusted,
 	normalize_project_trust_env_decision,
@@ -127,6 +128,84 @@ describe('apply_project_trust_untrusted_defaults', () => {
 			MY_PI_PROJECT_SKILLS: 'skip',
 			MY_PI_TEAM_PROFILES_PROJECT: 'skip',
 		});
+	});
+});
+
+describe('create_project_trust_wrapper', () => {
+	it('constructs the subject-specific store path from the agent directory', () => {
+		const wrapper = create_project_trust_wrapper({
+			store_filename: 'trusted-example.json',
+		});
+		process.env.PI_CODING_AGENT_DIR = '/tmp/my-pi-agent-dir';
+
+		expect(wrapper.default_trust_store_path()).toBe(
+			'/tmp/my-pi-agent-dir/trusted-example.json',
+		);
+
+		process.env.PI_CODING_AGENT_DIR = '~';
+		expect(wrapper.default_trust_store_path()).toBe(
+			join(homedir(), 'trusted-example.json'),
+		);
+	});
+
+	it('delegates current trust matching and persistence', () => {
+		const store = trust_store_path();
+		const target = subject();
+		const wrapper = create_project_trust_wrapper({
+			store_filename: 'trusted-example.json',
+		});
+
+		expect(wrapper.is_trusted(target, store)).toBe(false);
+		wrapper.trust(
+			target,
+			store,
+			new Date('2026-04-30T00:00:00.000Z'),
+		);
+
+		expect(wrapper.is_trusted(target, store)).toBe(true);
+		expect(
+			wrapper.is_trusted({ ...target, hash: 'hash-b' }, store),
+		).toBe(false);
+		expect(readFileSync(store, 'utf8')).toContain(
+			'2026-04-30T00:00:00.000Z',
+		);
+	});
+
+	it('uses an optional legacy matcher after current matching fails', () => {
+		const store = trust_store_path();
+		const target = subject();
+		const legacy_matcher = vi.fn(
+			(entry: unknown, current: { id: string; hash?: string }) => {
+				const legacy = entry as
+					| { path?: unknown; hash?: unknown }
+					| undefined;
+				return (
+					legacy?.path === current.id && legacy.hash === current.hash
+				);
+			},
+		);
+		const wrapper = create_project_trust_wrapper({
+			store_filename: 'trusted-example.json',
+			legacy_matcher,
+		});
+		mkdirSync(dirname(store), { recursive: true });
+		writeFileSync(
+			store,
+			JSON.stringify({
+				[target.id]: { path: target.id, hash: target.hash },
+			}),
+		);
+
+		expect(wrapper.is_trusted(target, store)).toBe(true);
+		expect(
+			wrapper.is_trusted({ ...target, hash: 'hash-b' }, store),
+		).toBe(false);
+		expect(legacy_matcher).toHaveBeenCalledTimes(2);
+
+		wrapper.trust(target, store);
+		legacy_matcher.mockClear();
+		expect(wrapper.is_trusted(target, store)).toBe(true);
+		expect(legacy_matcher).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/pi-project-trust/src/index.ts
+++ b/packages/pi-project-trust/src/index.ts
@@ -94,6 +94,34 @@ export type ProjectTrustStore = Record<
 	ProjectTrustStoreEntry
 >;
 
+export type ProjectTrustStoreSubject = Pick<
+	ProjectTrustSubject,
+	'id' | 'hash' | 'kind' | 'store_key'
+>;
+
+export type ProjectTrustLegacyMatcher = (
+	entry: unknown,
+	subject: ProjectTrustStoreSubject,
+) => boolean;
+
+export interface ProjectTrustWrapperOptions {
+	store_filename: string;
+	legacy_matcher?: ProjectTrustLegacyMatcher;
+}
+
+export interface ProjectTrustWrapper {
+	default_trust_store_path: () => string;
+	is_trusted: (
+		subject: ProjectTrustStoreSubject,
+		trust_store_path?: string,
+	) => boolean;
+	trust: (
+		subject: ProjectTrustStoreSubject,
+		trust_store_path?: string,
+		now?: Date,
+	) => void;
+}
+
 export const PROJECT_TRUST_UNTRUSTED_DEFAULTS: Record<
 	string,
 	string
@@ -112,7 +140,11 @@ const GLOBAL_FALLBACK_VALUES = new Set(['global', 'global-only']);
 
 function get_agent_dir(): string {
 	const configured = process.env.PI_CODING_AGENT_DIR;
-	if (configured?.startsWith('~/')) {
+	if (configured === '~') return homedir();
+	if (
+		configured?.startsWith('~/') ||
+		(process.platform === 'win32' && configured?.startsWith('~\\'))
+	) {
 		return join(homedir(), configured.slice(2));
 	}
 	return configured || join(homedir(), '.pi', 'agent');
@@ -120,6 +152,39 @@ function get_agent_dir(): string {
 
 export function default_project_trust_store_path(): string {
 	return join(get_agent_dir(), 'trusted-project-resources.json');
+}
+
+export function create_project_trust_wrapper(
+	options: ProjectTrustWrapperOptions,
+): ProjectTrustWrapper {
+	const default_trust_store_path = (): string =>
+		join(get_agent_dir(), options.store_filename);
+
+	return {
+		default_trust_store_path,
+		is_trusted: (
+			subject,
+			trust_store_path = default_trust_store_path(),
+		): boolean => {
+			if (is_project_subject_trusted(subject, trust_store_path)) {
+				return true;
+			}
+			if (!options.legacy_matcher) return false;
+
+			const entry =
+				read_project_trust_store(trust_store_path)[
+					get_project_trust_store_key(subject)
+				];
+			return options.legacy_matcher(entry, subject);
+		},
+		trust: (
+			subject,
+			trust_store_path = default_trust_store_path(),
+			now,
+		): void => {
+			trust_project_subject(subject, trust_store_path, now);
+		},
+	};
 }
 
 export function apply_project_trust_untrusted_defaults(
@@ -215,10 +280,7 @@ export function get_project_trust_store_key(
 }
 
 export function is_project_subject_trusted(
-	subject: Pick<
-		ProjectTrustSubject,
-		'id' | 'hash' | 'kind' | 'store_key'
-	>,
+	subject: ProjectTrustStoreSubject,
 	trust_store_path: string = default_project_trust_store_path(),
 ): boolean {
 	const store = read_project_trust_store(trust_store_path);
@@ -231,10 +293,7 @@ export function is_project_subject_trusted(
 }
 
 export function trust_project_subject(
-	subject: Pick<
-		ProjectTrustSubject,
-		'id' | 'hash' | 'kind' | 'store_key'
-	>,
+	subject: ProjectTrustStoreSubject,
 	trust_store_path: string = default_project_trust_store_path(),
 	now: Date = new Date(),
 ): void {

--- a/packages/pi-project-trust/src/index.ts
+++ b/packages/pi-project-trust/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export type ProjectTrustFallback = 'global';
 
@@ -146,6 +147,9 @@ function get_agent_dir(): string {
 		(process.platform === 'win32' && configured?.startsWith('~\\'))
 	) {
 		return join(homedir(), configured.slice(2));
+	}
+	if (configured?.startsWith('file://')) {
+		return fileURLToPath(configured);
 	}
 	return configured || join(homedir(), '.pi', 'agent');
 }

--- a/src/extensions/hooks-resolution/trust.test.ts
+++ b/src/extensions/hooks-resolution/trust.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, rmSync } from 'node:fs';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -57,5 +57,27 @@ describe('hook config trust', () => {
 			is_hooks_config_trusted(project_dir, 'hash-b', store),
 		).toBe(false);
 		expect(readFileSync(store, 'utf8')).toContain('trusted_at');
+	});
+
+	it('recognizes legacy hooks trust-store entries during migration', () => {
+		const store = trust_store_path();
+		const project_dir = '/repo';
+		writeFileSync(
+			store,
+			JSON.stringify({
+				[project_dir]: {
+					project_dir,
+					hash: 'hash-a',
+					trusted_at: '2026-04-30T00:00:00.000Z',
+				},
+			}),
+		);
+
+		expect(
+			is_hooks_config_trusted(project_dir, 'hash-a', store),
+		).toBe(true);
+		expect(
+			is_hooks_config_trusted(project_dir, 'hash-b', store),
+		).toBe(false);
 	});
 });

--- a/src/extensions/hooks-resolution/trust.ts
+++ b/src/extensions/hooks-resolution/trust.ts
@@ -1,16 +1,25 @@
-import { getAgentDir } from '@earendil-works/pi-coding-agent';
 import {
-	is_project_subject_trusted,
-	read_project_trust_store,
-	trust_project_subject,
+	create_project_trust_wrapper,
 	type ProjectTrustSubject,
 } from '@spences10/pi-project-trust';
-import { join } from 'node:path';
 
 const HOOKS_CONFIG_ENV = 'MY_PI_HOOKS_CONFIG';
 
+const hooks_config_trust = create_project_trust_wrapper({
+	store_filename: 'trusted-hooks.json',
+	legacy_matcher: (entry, subject) => {
+		const legacy_entry = entry as
+			| { project_dir?: unknown; hash?: unknown }
+			| undefined;
+		return (
+			legacy_entry?.project_dir === subject.id &&
+			legacy_entry.hash === subject.hash
+		);
+	},
+});
+
 export function default_hooks_trust_store_path(): string {
-	return join(getAgentDir(), 'trusted-hooks.json');
+	return hooks_config_trust.default_trust_store_path();
 }
 
 export function create_hooks_config_trust_subject(
@@ -33,19 +42,9 @@ export function is_hooks_config_trusted(
 	hash: string,
 	trust_store_path = default_hooks_trust_store_path(),
 ): boolean {
-	const subject = create_hooks_config_trust_subject(
-		project_dir,
-		hash,
-	);
-	if (is_project_subject_trusted(subject, trust_store_path))
-		return true;
-
-	const legacy_entry = read_project_trust_store(trust_store_path)[
-		project_dir
-	] as { project_dir?: unknown; hash?: unknown } | undefined;
-	return (
-		legacy_entry?.project_dir === project_dir &&
-		legacy_entry.hash === hash
+	return hooks_config_trust.is_trusted(
+		create_hooks_config_trust_subject(project_dir, hash),
+		trust_store_path,
 	);
 }
 
@@ -54,7 +53,7 @@ export function trust_hooks_config(
 	hash: string,
 	trust_store_path = default_hooks_trust_store_path(),
 ): void {
-	trust_project_subject(
+	hooks_config_trust.trust(
 		create_hooks_config_trust_subject(project_dir, hash),
 		trust_store_path,
 	);


### PR DESCRIPTION
## Summary

- add a generic `create_project_trust_wrapper()` helper for invariant store mechanics
- preserve MCP, LSP, and hooks subject fields, trust decisions, and legacy store matching
- add focused helper and hooks migration coverage plus patch Changesets for every affected publishable package

Closes #181

## Validation

- `pnpm --filter @spences10/pi-project-trust run check`
- `pnpm --filter @spences10/pi-project-trust run test` — 29 passed
- `pnpm --filter @spences10/pi-project-trust run build`
- `pnpm --filter @spences10/pi-mcp run check`
- `MY_PI_RUNTIME_MODE=interactive pnpm --filter @spences10/pi-mcp run test` — 65 passed
- `pnpm --filter @spences10/pi-mcp run build`
- `pnpm --filter @spences10/pi-lsp run check`
- `pnpm --filter @spences10/pi-lsp run test` — 41 passed
- `pnpm --filter @spences10/pi-lsp run build`
- `pnpm exec vp test src/extensions/hooks-resolution/trust.test.ts` — 3 passed
- `pnpm run check`
- `pnpm run build`
- `pnpm changeset status` — patch bumps for `my-pi`, `pi-project-trust`, `pi-factory`, `pi-mcp`, and `pi-lsp`
- Changeset prose word-count script — exactly 15 words
- `git diff --check`
- changed-file `lsp_diagnostics_many` attempted twice; unavailable because workspace TypeScript 7.0.2 does not provide the `tsserver.js` required by `typescript-language-server`

## Remaining risks

- The first MCP suite run inherited `MY_PI_RUNTIME_MODE=print` from the parent Pi process and failed one active-tool assertion; the explicit interactive-mode rerun passed all 65 tests.
- Changed-file LSP diagnostics could not initialize against TypeScript 7.0.2; package and root TypeScript checks passed as fallback evidence.
