### PR TITLE
refactor(skills): share scanner primitives

### DIFF
--- a/.changeset/tidy-skill-scanners.md
+++ b/.changeset/tidy-skill-scanners.md
@@ -1,0 +1,7 @@
+---
+'@spences10/pi-skill-importer': patch
+'@spences10/pi-skills': patch
+---
+
+Share scanner primitives across skill packages while preserving
+managed, project, and external discovery behavior consistently.

--- a/packages/pi-skill-importer/README.md
+++ b/packages/pi-skill-importer/README.md
@@ -61,6 +61,11 @@ import {
 } from '@spences10/pi-skill-importer';
 ```
 
+The package also exports `scan_skill_directory`,
+`dedupe_skills_by_path`, and `find_project_roots` for packages that
+need scanner-compatible discovery without duplicating filesystem
+behavior.
+
 ## Development
 
 <!-- package-readme:development:start commands="check,test" -->

--- a/packages/pi-skill-importer/src/index.ts
+++ b/packages/pi-skill-importer/src/index.ts
@@ -17,6 +17,14 @@ export {
 } from './scanner.js';
 
 export {
+	dedupe_skills_by_path,
+	find_project_roots,
+	scan_skill_directory,
+	type ScanSkillDirectoryOptions,
+	type ScannedSkill,
+} from './scanner-primitives.js';
+
+export {
 	delete_managed_skill as delete_imported_skill,
 	get_imported_skill_sync_status,
 	import_external_skill,

--- a/packages/pi-skill-importer/src/scanner-primitives.test.ts
+++ b/packages/pi-skill-importer/src/scanner-primitives.test.ts
@@ -1,0 +1,99 @@
+import {
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	dedupe_skills_by_path,
+	find_project_roots,
+	scan_skill_directory,
+} from './scanner-primitives.js';
+
+const temp_dirs: string[] = [];
+
+function make_temp_dir(): string {
+	const dir = mkdtempSync(join(tmpdir(), 'pi-skill-scanner-'));
+	temp_dirs.push(dir);
+	return dir;
+}
+
+function write_skill(
+	path: string,
+	description = 'Scanner fixture',
+): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(
+		path,
+		`---\ndescription: ${description}\n---\n\n# Fixture\n`,
+	);
+}
+
+afterEach(() => {
+	for (const dir of temp_dirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe('skill scanner primitives', () => {
+	it('preserves direct-root precedence and inferred names', () => {
+		const root = make_temp_dir();
+		write_skill(join(root, 'SKILL.md'), '  Direct fixture  ');
+		write_skill(join(root, 'nested', 'SKILL.md'));
+
+		expect(scan_skill_directory(root)).toEqual([
+			{
+				name: basename(root),
+				description: 'Direct fixture',
+				skillPath: join(root, 'SKILL.md'),
+				baseDir: root,
+			},
+		]);
+	});
+
+	it('sorts recursive and root Markdown skills while applying exclusions', () => {
+		const root = make_temp_dir();
+		write_skill(join(root, 'zeta', 'SKILL.md'));
+		write_skill(join(root, 'alpha', 'SKILL.md'));
+		write_skill(join(root, 'standalone.md'));
+
+		const skills = scan_skill_directory(root, {
+			include_direct_root_skill: false,
+			include_root_markdown_skills: true,
+			exclude_matches: (match) => match.startsWith('zeta/'),
+		});
+
+		expect(skills.map((skill) => skill.name)).toEqual([
+			'alpha',
+			'standalone',
+		]);
+	});
+
+	it('deduplicates by skill path while retaining the first match', () => {
+		const first = { skillPath: '/skills/example', source: 'first' };
+		const duplicate = {
+			skillPath: '/skills/example',
+			source: 'second',
+		};
+
+		expect(dedupe_skills_by_path([first, duplicate])).toEqual([
+			first,
+		]);
+	});
+
+	it('walks upward only through the nearest Git project root', () => {
+		const root = make_temp_dir();
+		const nested = join(root, 'one', 'two');
+		mkdirSync(join(root, '.git'));
+		mkdirSync(nested, { recursive: true });
+
+		expect(find_project_roots(nested)).toEqual([
+			nested,
+			join(root, 'one'),
+			root,
+		]);
+	});
+});

--- a/packages/pi-skill-importer/src/scanner-primitives.ts
+++ b/packages/pi-skill-importer/src/scanner-primitives.ts
@@ -1,0 +1,139 @@
+import {
+	parseFrontmatter,
+	type SkillFrontmatter,
+} from '@earendil-works/pi-coding-agent';
+import {
+	existsSync,
+	globSync,
+	readFileSync,
+	statSync,
+} from 'node:fs';
+import { basename, dirname, join, parse, resolve } from 'node:path';
+
+export interface ScannedSkill {
+	name: string;
+	description: string;
+	skillPath: string;
+	baseDir: string;
+}
+
+export interface ScanSkillDirectoryOptions {
+	include_direct_root_skill?: boolean;
+	include_root_markdown_skills?: boolean;
+	exclude_matches?: (match: string) => boolean;
+}
+
+function parse_skill_markdown(
+	skill_path: string,
+): { name: string; description: string } | null {
+	try {
+		const content = readFileSync(skill_path, 'utf-8');
+		const { frontmatter } =
+			parseFrontmatter<SkillFrontmatter>(content);
+		const description = frontmatter?.description;
+		if (!description) return null;
+
+		const name =
+			frontmatter?.name ||
+			(basename(skill_path) === 'SKILL.md'
+				? basename(dirname(skill_path))
+				: parse(skill_path).name);
+		return { name, description: description.trim() };
+	} catch {
+		return null;
+	}
+}
+
+export function scan_skill_directory(
+	dir: string,
+	options: ScanSkillDirectoryOptions = {},
+): ScannedSkill[] {
+	if (!existsSync(dir)) return [];
+
+	const results: ScannedSkill[] = [];
+	const direct = join(dir, 'SKILL.md');
+	const include_direct_root_skill =
+		options.include_direct_root_skill ?? true;
+
+	if (include_direct_root_skill && existsSync(direct)) {
+		const parsed = parse_skill_markdown(direct);
+		if (parsed) {
+			results.push({
+				...parsed,
+				skillPath: direct,
+				baseDir: dir,
+			});
+		}
+		return results;
+	}
+
+	try {
+		const matches = globSync('**/SKILL.md', { cwd: dir });
+		if (options.include_root_markdown_skills) {
+			matches.push(
+				...globSync('*.md', { cwd: dir }).filter(
+					(match) => match !== 'SKILL.md',
+				),
+			);
+		}
+		for (const match of matches
+			.filter((candidate) => !options.exclude_matches?.(candidate))
+			.sort((a, b) => a.localeCompare(b))) {
+			const full_path = resolve(dir, match);
+			const parsed = parse_skill_markdown(full_path);
+			if (parsed) {
+				results.push({
+					...parsed,
+					skillPath: full_path,
+					baseDir: dirname(full_path),
+				});
+			}
+		}
+	} catch {
+		// Skip inaccessible directories.
+	}
+
+	return results;
+}
+
+export function dedupe_skills_by_path<
+	Skill extends { skillPath: string },
+>(skills: readonly Skill[]): Skill[] {
+	const seen = new Set<string>();
+	const deduped: Skill[] = [];
+
+	for (const skill of skills) {
+		if (seen.has(skill.skillPath)) continue;
+		seen.add(skill.skillPath);
+		deduped.push(skill);
+	}
+
+	return deduped;
+}
+
+function parent_dir(path: string): string | null {
+	const parsed = parse(path);
+	const parent = dirname(path);
+	return parent === path || parent === parsed.root ? null : parent;
+}
+
+function is_directory(path: string): boolean {
+	try {
+		return statSync(path).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+export function find_project_roots(cwd: string): string[] {
+	const roots: string[] = [];
+	let current = resolve(cwd);
+	while (true) {
+		roots.push(current);
+		if (is_directory(join(current, '.git'))) break;
+		const parent = parent_dir(current);
+		if (!parent) break;
+		current = parent;
+	}
+	return roots;
+}

--- a/packages/pi-skill-importer/src/scanner.test.ts
+++ b/packages/pi-skill-importer/src/scanner.test.ts
@@ -1,9 +1,41 @@
-import { describe, expect, it } from 'vitest';
+import {
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
 	is_importable_skill,
 	is_imported_skill,
+	scan_project_skills,
 	type DiscoveredSkill,
 } from './scanner.js';
+
+const temp_dirs: string[] = [];
+
+function make_project(): string {
+	const root = mkdtempSync(join(tmpdir(), 'pi-importer-project-'));
+	temp_dirs.push(root);
+	mkdirSync(join(root, '.git'));
+	return root;
+}
+
+function write_skill(path: string): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(
+		path,
+		'---\ndescription: Scanner fixture\n---\n\n# Fixture\n',
+	);
+}
+
+afterEach(() => {
+	for (const dir of temp_dirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
 
 const base_skill: DiscoveredSkill = {
 	name: 'example',
@@ -35,6 +67,51 @@ describe('packages/pi-skill-importer/src/scanner.ts', () => {
 
 		expect(is_importable_skill(importable)).toBe(true);
 		expect(is_importable_skill(base_skill)).toBe(false);
+	});
+
+	it('preserves project sources, root Markdown skills, and deduplication', () => {
+		const root = make_project();
+		write_skill(join(root, '.agents', 'general', 'SKILL.md'));
+		write_skill(
+			join(root, '.agents', 'skills', 'shared', 'SKILL.md'),
+		);
+		write_skill(join(root, '.pi', 'skills', 'standalone.md'));
+
+		expect(
+			scan_project_skills(root).map(
+				({ name, source, scope, skillPath }) => ({
+					name,
+					source,
+					scope,
+					skillPath,
+				}),
+			),
+		).toEqual([
+			{
+				name: 'general',
+				source: 'project:.agents',
+				scope: 'project',
+				skillPath: join(root, '.agents', 'general', 'SKILL.md'),
+			},
+			{
+				name: 'shared',
+				source: 'project:.agents/skills',
+				scope: 'project',
+				skillPath: join(
+					root,
+					'.agents',
+					'skills',
+					'shared',
+					'SKILL.md',
+				),
+			},
+			{
+				name: 'standalone',
+				source: 'project:.pi/skills',
+				scope: 'project',
+				skillPath: join(root, '.pi', 'skills', 'standalone.md'),
+			},
+		]);
 	});
 
 	it('narrows managed copies with importer provenance', () => {

--- a/packages/pi-skill-importer/src/scanner.ts
+++ b/packages/pi-skill-importer/src/scanner.ts
@@ -1,16 +1,14 @@
-import {
-	getAgentDir,
-	parseFrontmatter,
-	type SkillFrontmatter,
-} from '@earendil-works/pi-coding-agent';
-import {
-	existsSync,
-	globSync,
-	readFileSync,
-	statSync,
-} from 'node:fs';
+import { getAgentDir } from '@earendil-works/pi-coding-agent';
+import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { basename, dirname, join, parse, resolve } from 'node:path';
+import { join } from 'node:path';
+import {
+	dedupe_skills_by_path,
+	find_project_roots,
+	scan_skill_directory,
+	type ScanSkillDirectoryOptions,
+	type ScannedSkill,
+} from './scanner-primitives.js';
 
 export const IMPORT_METADATA_FILE = '.my-pi-source.json';
 
@@ -108,27 +106,6 @@ function read_installed_plugins(): InstalledPluginsFile | null {
 	}
 }
 
-function parse_skill_md(
-	skill_path: string,
-): { name: string; description: string } | null {
-	try {
-		const content = readFileSync(skill_path, 'utf-8');
-		const { frontmatter } =
-			parseFrontmatter<SkillFrontmatter>(content);
-		const description = frontmatter?.description;
-		if (!description) return null;
-
-		const name =
-			frontmatter?.name ||
-			(basename(skill_path) === 'SKILL.md'
-				? basename(dirname(skill_path))
-				: parse(skill_path).name);
-		return { name, description: description.trim() };
-	} catch {
-		return null;
-	}
-}
-
 function read_import_metadata(
 	base_dir: string,
 ): ImportedSkillMetadata | undefined {
@@ -144,96 +121,37 @@ function read_import_metadata(
 	}
 }
 
-function scan_dir_for_skills(
-	dir: string,
-	options: {
-		source: string;
-		scope: SkillScope;
-		kind: 'managed' | 'external';
-		plugin?: PluginSkillSource;
-		include_direct_root_skill?: boolean;
-		include_root_markdown_skills?: boolean;
-		exclude_matches?: (match: string) => boolean;
-	},
-): DiscoveredSkill[] {
-	if (!existsSync(dir)) return [];
-
-	const results: DiscoveredSkill[] = [];
-	const direct = join(dir, 'SKILL.md');
-	const include_direct_root_skill =
-		options.include_direct_root_skill ?? true;
-
-	if (include_direct_root_skill && existsSync(direct)) {
-		const parsed = parse_skill_md(direct);
-		if (parsed) {
-			results.push({
-				...parsed,
-				skillPath: direct,
-				baseDir: dir,
-				source: options.source,
-				scope: options.scope,
-				kind: options.kind,
-				plugin: options.plugin,
-				import_meta:
-					options.kind === 'managed'
-						? read_import_metadata(dir)
-						: undefined,
-			});
-		}
-		return results;
-	}
-
-	try {
-		const matches = globSync('**/SKILL.md', { cwd: dir });
-		if (options.include_root_markdown_skills) {
-			matches.push(
-				...globSync('*.md', { cwd: dir }).filter(
-					(match) => match !== 'SKILL.md',
-				),
-			);
-		}
-		for (const match of matches
-			.filter((candidate) => !options.exclude_matches?.(candidate))
-			.sort((a, b) => a.localeCompare(b))) {
-			const full_path = resolve(dir, match);
-			const parsed = parse_skill_md(full_path);
-			if (parsed) {
-				const base_dir = dirname(full_path);
-				results.push({
-					...parsed,
-					skillPath: full_path,
-					baseDir: base_dir,
-					source: options.source,
-					scope: options.scope,
-					kind: options.kind,
-					plugin: options.plugin,
-					import_meta:
-						options.kind === 'managed'
-							? read_import_metadata(base_dir)
-							: undefined,
-				});
-			}
-		}
-	} catch {
-		// skip inaccessible dirs
-	}
-
-	return results;
+interface DiscoveredSkillScanOptions extends ScanSkillDirectoryOptions {
+	source: string;
+	scope: SkillScope;
+	kind: 'managed' | 'external';
+	plugin?: PluginSkillSource;
 }
 
-function dedupe_by_skill_path(
-	skills: DiscoveredSkill[],
+function to_discovered_skill(
+	skill: ScannedSkill,
+	options: DiscoveredSkillScanOptions,
+): DiscoveredSkill {
+	return {
+		...skill,
+		source: options.source,
+		scope: options.scope,
+		kind: options.kind,
+		plugin: options.plugin,
+		import_meta:
+			options.kind === 'managed'
+				? read_import_metadata(skill.baseDir)
+				: undefined,
+	};
+}
+
+function scan_dir_for_skills(
+	dir: string,
+	options: DiscoveredSkillScanOptions,
 ): DiscoveredSkill[] {
-	const seen = new Set<string>();
-	const deduped: DiscoveredSkill[] = [];
-
-	for (const skill of skills) {
-		if (seen.has(skill.skillPath)) continue;
-		seen.add(skill.skillPath);
-		deduped.push(skill);
-	}
-
-	return deduped;
+	return scan_skill_directory(dir, options).map((skill) =>
+		to_discovered_skill(skill, options),
+	);
 }
 
 export function scan_managed_skills(): DiscoveredSkill[] {
@@ -263,34 +181,7 @@ export function scan_managed_skills(): DiscoveredSkill[] {
 		skills.push(skill);
 	}
 
-	return dedupe_by_skill_path(skills);
-}
-
-function parent_dir(path: string): string | null {
-	const parsed = parse(path);
-	const parent = dirname(path);
-	return parent === path || parent === parsed.root ? null : parent;
-}
-
-function is_directory(path: string): boolean {
-	try {
-		return statSync(path).isDirectory();
-	} catch {
-		return false;
-	}
-}
-
-function project_roots(cwd: string): string[] {
-	const roots: string[] = [];
-	let current = resolve(cwd);
-	while (true) {
-		roots.push(current);
-		if (is_directory(join(current, '.git'))) break;
-		const parent = parent_dir(current);
-		if (!parent) break;
-		current = parent;
-	}
-	return roots;
+	return dedupe_skills_by_path(skills);
 }
 
 export function scan_imported_skills(): ImportedSkill[] {
@@ -301,7 +192,7 @@ export function scan_project_skills(
 	cwd = process.cwd(),
 ): DiscoveredSkill[] {
 	const skills: DiscoveredSkill[] = [];
-	for (const root of project_roots(cwd)) {
+	for (const root of find_project_roots(cwd)) {
 		for (const skill of scan_dir_for_skills(join(root, '.agents'), {
 			source: 'project:.agents',
 			scope: 'project',
@@ -335,7 +226,7 @@ export function scan_project_skills(
 			skills.push(skill);
 		}
 	}
-	return dedupe_by_skill_path(skills);
+	return dedupe_skills_by_path(skills);
 }
 
 export function scan_importable_skills(): ImportableSkill[] {
@@ -384,30 +275,16 @@ export function scan_importable_skills(): ImportableSkill[] {
 
 		const direct_root_skill = join(entry.installPath, 'SKILL.md');
 		if (existsSync(direct_root_skill)) {
-			const parsed = parse_skill_md(direct_root_skill);
-			if (parsed) {
-				skills.push({
-					...parsed,
-					skillPath: direct_root_skill,
-					baseDir: entry.installPath,
-					source,
-					scope: 'plugin',
-					kind: 'external',
-					plugin,
-				});
+			for (const skill of scan_dir_for_skills(entry.installPath, {
+				source,
+				scope: 'plugin',
+				kind: 'external',
+				plugin,
+			})) {
+				skills.push(skill);
 			}
 		}
 	}
 
-	return dedupe_by_skill_path(skills).filter(is_importable_skill);
-}
-
-export function scan_all_skills(
-	cwd = process.cwd(),
-): DiscoveredSkill[] {
-	return [
-		...scan_managed_skills(),
-		...scan_project_skills(cwd),
-		...scan_importable_skills(),
-	];
+	return dedupe_skills_by_path(skills).filter(is_importable_skill);
 }

--- a/packages/pi-skills/src/scanner.test.ts
+++ b/packages/pi-skills/src/scanner.test.ts
@@ -1,7 +1,84 @@
-import { describe, expect, it } from 'vitest';
+import {
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { scan_project_skills } from './scanner.js';
+
+const temp_dirs: string[] = [];
+
+function make_project(): string {
+	const root = mkdtempSync(join(tmpdir(), 'pi-skills-project-'));
+	temp_dirs.push(root);
+	mkdirSync(join(root, '.git'));
+	return root;
+}
+
+function write_skill(path: string): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(
+		path,
+		'---\ndescription: Scanner fixture\n---\n\n# Fixture\n',
+	);
+}
+
+afterEach(() => {
+	for (const dir of temp_dirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
 
 describe('packages/pi-skills/src/scanner.ts', () => {
 	it('loads without side effects', async () => {
 		await expect(import('./scanner.js')).resolves.toBeDefined();
+	});
+
+	it('preserves project sources, root Markdown skills, and deduplication', () => {
+		const root = make_project();
+		write_skill(join(root, '.agents', 'general', 'SKILL.md'));
+		write_skill(
+			join(root, '.agents', 'skills', 'shared', 'SKILL.md'),
+		);
+		write_skill(join(root, '.pi', 'skills', 'standalone.md'));
+
+		expect(
+			scan_project_skills(root).map(
+				({ name, source, scope, skillPath }) => ({
+					name,
+					source,
+					scope,
+					skillPath,
+				}),
+			),
+		).toEqual([
+			{
+				name: 'general',
+				source: 'project:.agents',
+				scope: 'project',
+				skillPath: join(root, '.agents', 'general', 'SKILL.md'),
+			},
+			{
+				name: 'shared',
+				source: 'project:.agents/skills',
+				scope: 'project',
+				skillPath: join(
+					root,
+					'.agents',
+					'skills',
+					'shared',
+					'SKILL.md',
+				),
+			},
+			{
+				name: 'standalone',
+				source: 'project:.pi/skills',
+				scope: 'project',
+				skillPath: join(root, '.pi', 'skills', 'standalone.md'),
+			},
+		]);
 	});
 });

--- a/packages/pi-skills/src/scanner.ts
+++ b/packages/pi-skills/src/scanner.ts
@@ -1,15 +1,11 @@
+import { getAgentDir } from '@earendil-works/pi-coding-agent';
 import {
-	getAgentDir,
-	parseFrontmatter,
-	type SkillFrontmatter,
-} from '@earendil-works/pi-coding-agent';
-import {
-	existsSync,
-	globSync,
-	readFileSync,
-	statSync,
-} from 'node:fs';
-import { basename, dirname, join, parse, resolve } from 'node:path';
+	dedupe_skills_by_path,
+	find_project_roots,
+	scan_skill_directory,
+	type ScanSkillDirectoryOptions,
+} from '@spences10/pi-skill-importer';
+import { join } from 'node:path';
 
 export type SkillScope = 'global' | 'project';
 
@@ -23,109 +19,25 @@ export interface DiscoveredSkill {
 	kind: 'managed';
 }
 
-function parse_skill_md(
-	skill_path: string,
-): { name: string; description: string } | null {
-	try {
-		const content = readFileSync(skill_path, 'utf-8');
-		const { frontmatter } =
-			parseFrontmatter<SkillFrontmatter>(content);
-		const description = frontmatter?.description;
-		if (!description) return null;
-
-		const name =
-			frontmatter?.name ||
-			(basename(skill_path) === 'SKILL.md'
-				? parse(dirname(skill_path)).base
-				: parse(skill_path).name);
-		return { name, description: description.trim() };
-	} catch {
-		return null;
-	}
+interface ManagedSkillScanOptions extends ScanSkillDirectoryOptions {
+	source: string;
+	scope: SkillScope;
 }
 
 function scan_dir_for_skills(
 	dir: string,
-	options: {
-		source: string;
-		scope: SkillScope;
-		include_direct_root_skill?: boolean;
-		include_root_markdown_skills?: boolean;
-		exclude_matches?: (match: string) => boolean;
-	},
+	options: ManagedSkillScanOptions,
 ): DiscoveredSkill[] {
-	if (!existsSync(dir)) return [];
-
-	const results: DiscoveredSkill[] = [];
-	const direct = join(dir, 'SKILL.md');
-	const include_direct_root_skill =
-		options.include_direct_root_skill ?? true;
-
-	if (include_direct_root_skill && existsSync(direct)) {
-		const parsed = parse_skill_md(direct);
-		if (parsed) {
-			results.push({
-				...parsed,
-				skillPath: direct,
-				baseDir: dir,
-				source: options.source,
-				scope: options.scope,
-				kind: 'managed',
-			});
-		}
-		return results;
-	}
-
-	try {
-		const matches = globSync('**/SKILL.md', { cwd: dir });
-		if (options.include_root_markdown_skills) {
-			matches.push(
-				...globSync('*.md', { cwd: dir }).filter(
-					(match) => match !== 'SKILL.md',
-				),
-			);
-		}
-		for (const match of matches
-			.filter((candidate) => !options.exclude_matches?.(candidate))
-			.sort((a, b) => a.localeCompare(b))) {
-			const full_path = resolve(dir, match);
-			const parsed = parse_skill_md(full_path);
-			if (parsed) {
-				const base_dir = dirname(full_path);
-				results.push({
-					...parsed,
-					skillPath: full_path,
-					baseDir: base_dir,
-					source: options.source,
-					scope: options.scope,
-					kind: 'managed',
-				});
-			}
-		}
-	} catch {
-		// skip inaccessible dirs
-	}
-
-	return results;
-}
-
-function dedupe_by_skill_path(
-	skills: DiscoveredSkill[],
-): DiscoveredSkill[] {
-	const seen = new Set<string>();
-	const deduped: DiscoveredSkill[] = [];
-
-	for (const skill of skills) {
-		if (seen.has(skill.skillPath)) continue;
-		seen.add(skill.skillPath);
-		deduped.push(skill);
-	}
-
-	return deduped;
+	return scan_skill_directory(dir, options).map((skill) => ({
+		...skill,
+		source: options.source,
+		scope: options.scope,
+		kind: 'managed',
+	}));
 }
 
 export function scan_managed_skills(): DiscoveredSkill[] {
-	return dedupe_by_skill_path(
+	return dedupe_skills_by_path(
 		scan_dir_for_skills(join(getAgentDir(), 'skills'), {
 			source: 'pi-native',
 			scope: 'global',
@@ -135,38 +47,11 @@ export function scan_managed_skills(): DiscoveredSkill[] {
 	);
 }
 
-function parent_dir(path: string): string | null {
-	const parsed = parse(path);
-	const parent = dirname(path);
-	return parent === path || parent === parsed.root ? null : parent;
-}
-
-function is_directory(path: string): boolean {
-	try {
-		return statSync(path).isDirectory();
-	} catch {
-		return false;
-	}
-}
-
-function project_roots(cwd: string): string[] {
-	const roots: string[] = [];
-	let current = resolve(cwd);
-	while (true) {
-		roots.push(current);
-		if (is_directory(join(current, '.git'))) break;
-		const parent = parent_dir(current);
-		if (!parent) break;
-		current = parent;
-	}
-	return roots;
-}
-
 export function scan_project_skills(
 	cwd = process.cwd(),
 ): DiscoveredSkill[] {
 	const skills: DiscoveredSkill[] = [];
-	for (const root of project_roots(cwd)) {
+	for (const root of find_project_roots(cwd)) {
 		for (const skill of scan_dir_for_skills(join(root, '.agents'), {
 			source: 'project:.agents',
 			scope: 'project',
@@ -197,11 +82,5 @@ export function scan_project_skills(
 			skills.push(skill);
 		}
 	}
-	return dedupe_by_skill_path(skills);
-}
-
-export function scan_all_skills(
-	cwd = process.cwd(),
-): DiscoveredSkill[] {
-	return [...scan_managed_skills(), ...scan_project_skills(cwd)];
+	return dedupe_skills_by_path(skills);
 }


### PR DESCRIPTION
## Summary

- extract shared skill-directory, path-deduplication, and project-root scanner primitives into `pi-skill-importer`
- consume those primitives from `pi-skills` in the existing dependency direction, avoiding a package cycle
- remove both unused `scan_all_skills` implementations and add focused filesystem-backed behavior tests
- add patch Changesets for both affected publishable packages with an explicitly verified fifteen-word description

Closes #175

## Validation

- `pnpm --filter @spences10/pi-skill-importer run check` — passed
- `pnpm --filter @spences10/pi-skill-importer run test` — passed (4 files, 18 tests)
- `pnpm --filter @spences10/pi-skill-importer run build` — passed
- `pnpm --filter @spences10/pi-skills run check` — passed
- `pnpm --filter @spences10/pi-skills run test` — passed (17 files, 67 tests)
- `pnpm --filter @spences10/pi-skills run build` — passed
- `pnpm run check` — passed, including docs, formatting, types, and boundaries
- `pnpm changeset status` — passed; patch releases detected for both affected packages
- Changeset prose word count — explicitly verified as `15`
- `git diff --check` — passed
- GitHub PR checks — passed (`ci`, `changes`, `semgrep-oss/scan`, and Workers Builds)
- changed-file LSP diagnostics — attempted for all seven changed TypeScript files; unavailable because `typescript-language-server` 5.3.0 rejected workspace TypeScript 7.0.2
- `pnpm run test` — failed at `packages/pi-mcp/src/index.test.ts:250`; expected `setActiveTools(['mcp__demo__ping'])`, but it received zero calls
- `pnpm --filter @spences10/pi-mcp run test:self -- src/index.test.ts -t 'connects enabled servers before the first agent turn'` — reproduced the same single failure (1 failed, 64 passed)

## Review

Independent read-only `gpt-5.6-sol` review: **APPROVE**, with no findings.

## Remaining risks

- The local repository-wide test suite remains red at the documented `pi-mcp` active-tool assertion, although GitHub CI passes; this branch does not modify `pi-mcp`.
- Changed-file LSP diagnostics could not initialize with the repository's TypeScript 7.0.2 installation; affected package and root TypeScript checks passed.
