### PR TITLE
feat: adopt named inline extensions

### DIFF
--- a/.changeset/named-inline-extensions.md
+++ b/.changeset/named-inline-extensions.md
@@ -1,0 +1,6 @@
+---
+'my-pi': patch
+---
+
+Adopt named inline extensions for descriptive startup labels while
+preserving managed precedence and consumer compatibility.

--- a/.changeset/named-inline-extensions.md
+++ b/.changeset/named-inline-extensions.md
@@ -2,5 +2,5 @@
 'my-pi': patch
 ---
 
-Adopt named inline extensions for descriptive startup labels while
-preserving managed precedence and consumer compatibility.
+Adopt named inline extensions with reserved managed labels, preserved
+precedence, and documented consumer naming rules.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ const runtime = await create_my_pi({
 ```
 
 The wrapper above appears as `<inline:audit-events>` in Pi's startup
-Extensions list.
+Extensions list. Names beginning with `my-pi-` are reserved for the
+managed distribution extensions; `create_my_pi()` rejects consumer
+wrappers using that prefix before loading any extensions.
 
 ## What you get
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,30 @@ Use this path if you already have your own Pi setup and only want
 selected features. Package READMEs are the source of truth for install
 instructions, commands, configuration, and runtime behavior.
 
+### Programmatic use
+
+`create_my_pi()` accepts upstream `InlineExtension` values, including
+named wrappers that keep startup extension paths descriptive. Bare
+factory functions remain supported.
+
+```typescript
+import { create_my_pi, type InlineExtension } from 'my-pi';
+
+const audit_extension: InlineExtension = {
+	name: 'audit-events',
+	factory(pi) {
+		pi.on('agent_start', () => console.log('agent started'));
+	},
+};
+
+const runtime = await create_my_pi({
+	extensionFactories: [audit_extension],
+});
+```
+
+The wrapper above appears as `<inline:audit-events>` in Pi's startup
+Extensions list.
+
 ## What you get
 
 - **Pi-native CLI + SDK wrapper** — interactive TUI, print mode, JSON

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -416,6 +416,69 @@ describe('create_my_pi environment scoping', () => {
 		}
 	});
 
+	it('uses descriptive startup paths for managed and consumer-named inline extensions', async () => {
+		const cwd = mkdtempSync(join(tmpdir(), 'my-pi-api-inline-ext-'));
+		const agent_dir = join(cwd, 'agent');
+
+		try {
+			const runtime = await create_my_pi({
+				cwd,
+				agent_dir,
+				runtime_mode: 'json',
+				extensionFactories: [
+					{
+						name: 'consumer-named',
+						factory(pi) {
+							pi.registerCommand('consumer-named-smoke', {
+								description: 'Named inline extension smoke test',
+								async handler() {},
+							});
+						},
+					},
+					(pi) => {
+						pi.registerCommand('consumer-bare-smoke', {
+							description: 'Bare inline extension smoke test',
+							async handler() {},
+						});
+					},
+				],
+				...disabled_builtins,
+			});
+
+			try {
+				const extensions =
+					runtime.services.resourceLoader.getExtensions().extensions;
+				const paths = extensions.map((extension) => extension.path);
+				const managed_paths = [
+					'<inline:my-pi-telemetry>',
+					'<inline:my-pi-extensions-manager>',
+					...BUILTIN_EXTENSIONS.map(
+						(extension) => `<inline:my-pi-${extension.key}>`,
+					),
+				];
+
+				expect(paths.slice(0, managed_paths.length)).toEqual(
+					managed_paths,
+				);
+				expect(paths).toContain('<inline:consumer-named>');
+				expect(
+					extensions.flatMap((extension) => [
+						...extension.commands.keys(),
+					]),
+				).toEqual(
+					expect.arrayContaining([
+						'consumer-named-smoke',
+						'consumer-bare-smoke',
+					]),
+				);
+			} finally {
+				await runtime.dispose();
+			}
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
 	it('loads TypeScript extension files through the upstream extension loader', async () => {
 		const cwd = mkdtempSync(join(tmpdir(), 'my-pi-api-ts-ext-'));
 		const agent_dir = join(cwd, 'agent');

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -479,6 +479,32 @@ describe('create_my_pi environment scoping', () => {
 		}
 	});
 
+	it('rejects managed-name collisions before path ownership can hide flag conflicts', async () => {
+		let consumer_factory_ran = false;
+
+		await expect(
+			create_my_pi({
+				extensionFactories: [
+					{
+						name: 'my-pi-observability',
+						factory(pi) {
+							consumer_factory_ran = true;
+							pi.registerFlag('observability-url', {
+								type: 'string',
+							});
+						},
+					},
+				],
+			}),
+		).rejects.toThrow(
+			'Inline extension name "my-pi-observability" is reserved for my-pi managed extensions',
+		);
+		expect(consumer_factory_ran).toBe(false);
+		expect(process.env.MY_PI_RUNTIME_MODE).toBe(
+			original_runtime_mode,
+		);
+	});
+
 	it('loads TypeScript extension files through the upstream extension loader', async () => {
 		const cwd = mkdtempSync(join(tmpdir(), 'my-pi-api-ts-ext-'));
 		const agent_dir = join(cwd, 'agent');

--- a/src/api.ts
+++ b/src/api.ts
@@ -14,7 +14,9 @@ import {
 } from '@earendil-works/pi-coding-agent';
 import { resolve } from 'node:path';
 import {
+	MANAGED_INLINE_EXTENSION_NAME_PREFIX,
 	PACKAGE_THEME_DIR,
+	assert_unreserved_inline_extension_names,
 	create_extensions_override,
 	create_lazy_builtin_extension_factory,
 	create_lazy_telemetry_extension,
@@ -82,6 +84,8 @@ export async function create_my_pi(options: CreateMyPiOptions = {}) {
 		untrusted_repo = false,
 	} = options;
 
+	assert_unreserved_inline_extension_names(user_factories);
+
 	const env_keys_to_restore = new Set<string>([
 		MY_PI_RUNTIME_MODE_ENV,
 	]);
@@ -132,7 +136,7 @@ export async function create_my_pi(options: CreateMyPiOptions = {}) {
 
 	const managed_inline_extensions = [
 		{
-			name: 'my-pi-telemetry',
+			name: `${MANAGED_INLINE_EXTENSION_NAME_PREFIX}telemetry`,
 			factory: create_lazy_telemetry_extension({
 				enabled: telemetry,
 				db_path: telemetry_db_path,
@@ -140,11 +144,11 @@ export async function create_my_pi(options: CreateMyPiOptions = {}) {
 			}),
 		},
 		{
-			name: 'my-pi-extensions-manager',
+			name: `${MANAGED_INLINE_EXTENSION_NAME_PREFIX}extensions-manager`,
 			factory: create_extensions_extension({ force_disabled }),
 		},
 		...BUILTIN_EXTENSION_REGISTRY.map((extension) => ({
-			name: `my-pi-${extension.key}`,
+			name: `${MANAGED_INLINE_EXTENSION_NAME_PREFIX}${extension.key}`,
 			factory: create_lazy_builtin_extension_factory(
 				extension.key,
 				extension.load,

--- a/src/api.ts
+++ b/src/api.ts
@@ -9,7 +9,7 @@ import {
 	runRpcMode,
 	type CreateAgentSessionFromServicesOptions,
 	type CreateAgentSessionServicesOptions,
-	type ExtensionFactory,
+	type InlineExtension,
 	type SessionManager,
 } from '@earendil-works/pi-coding-agent';
 import { resolve } from 'node:path';
@@ -130,23 +130,30 @@ export async function create_my_pi(options: CreateMyPiOptions = {}) {
 			})
 		: undefined;
 
-	const managed_extension_factories: ExtensionFactory[] = [
-		create_lazy_telemetry_extension({
-			enabled: telemetry,
-			db_path: telemetry_db_path,
-			cwd,
-		}),
-		create_extensions_extension({ force_disabled }),
-		...BUILTIN_EXTENSION_REGISTRY.map((extension) =>
-			create_lazy_builtin_extension_factory(
+	const managed_inline_extensions = [
+		{
+			name: 'my-pi-telemetry',
+			factory: create_lazy_telemetry_extension({
+				enabled: telemetry,
+				db_path: telemetry_db_path,
+				cwd,
+			}),
+		},
+		{
+			name: 'my-pi-extensions-manager',
+			factory: create_extensions_extension({ force_disabled }),
+		},
+		...BUILTIN_EXTENSION_REGISTRY.map((extension) => ({
+			name: `my-pi-${extension.key}`,
+			factory: create_lazy_builtin_extension_factory(
 				extension.key,
 				extension.load,
 				force_disabled,
 			),
-		),
-	];
-	const managed_inline_paths = managed_extension_factories.map(
-		(_, index) => `<inline:${index + 1}>`,
+		})),
+	] satisfies InlineExtension[];
+	const managed_extension_paths = managed_inline_extensions.map(
+		(extension) => `<inline:${extension.name}>`,
 	);
 
 	const create_runtime = async ({
@@ -195,11 +202,11 @@ export async function create_my_pi(options: CreateMyPiOptions = {}) {
 					? { additionalThemePaths: [PACKAGE_THEME_DIR] }
 					: {}),
 				extensionFactories: [
-					...managed_extension_factories,
+					...managed_inline_extensions,
 					...user_factories,
 				],
 				extensionsOverride: create_extensions_override(
-					managed_inline_paths,
+					managed_extension_paths,
 				),
 				skillsOverride: (
 					base: Parameters<
@@ -301,6 +308,7 @@ export { InteractiveMode, runPrintMode, runRpcMode };
 export type {
 	AgentSessionRuntime,
 	ExtensionFactory,
+	InlineExtension,
 	InteractiveModeOptions,
 	PrintModeOptions,
 } from '@earendil-works/pi-coding-agent';

--- a/src/api/builtin-extensions.test.ts
+++ b/src/api/builtin-extensions.test.ts
@@ -117,16 +117,6 @@ describe('builtin extension api helpers', () => {
 			'<inline:my-pi-telemetry>',
 			'<inline:my-pi-mcp>',
 		]);
-		const managed_telemetry = {
-			path: '<inline:my-pi-telemetry>',
-			commands: new Map(),
-			tools: new Map(),
-		};
-		const consumer_collision = {
-			path: '<inline:my-pi-telemetry>',
-			commands: new Map(),
-			tools: new Map(),
-		};
 		const result = override({
 			extensions: [
 				{ path: '/user', commands: new Map(), tools: new Map() },
@@ -135,16 +125,26 @@ describe('builtin extension api helpers', () => {
 					commands: new Map(),
 					tools: new Map(),
 				},
-				managed_telemetry,
-				consumer_collision,
+				{
+					path: '<inline:my-pi-telemetry>',
+					commands: new Map(),
+					tools: new Map(),
+				},
+				{
+					path: '<inline:consumer>',
+					commands: new Map(),
+					tools: new Map(),
+				},
 			],
 		} as Parameters<typeof override>[0]);
 
-		expect(result.extensions).toEqual([
-			managed_telemetry,
-			expect.objectContaining({ path: '<inline:my-pi-mcp>' }),
-			expect.objectContaining({ path: '/user' }),
-			consumer_collision,
+		expect(
+			result.extensions.map((extension) => extension.path),
+		).toEqual([
+			'<inline:my-pi-telemetry>',
+			'<inline:my-pi-mcp>',
+			'/user',
+			'<inline:consumer>',
 		]);
 	});
 });

--- a/src/api/builtin-extensions.test.ts
+++ b/src/api/builtin-extensions.test.ts
@@ -112,21 +112,39 @@ describe('builtin extension api helpers', () => {
 		expect(loaded).toBe(1);
 	});
 
-	it('keeps managed inline extensions ordered before user extensions', () => {
+	it('keeps managed extensions in precedence order before user extensions', () => {
 		const override = create_extensions_override([
-			'<inline:1>',
-			'<inline:2>',
+			'<inline:my-pi-telemetry>',
+			'<inline:my-pi-mcp>',
 		]);
+		const managed_telemetry = {
+			path: '<inline:my-pi-telemetry>',
+			commands: new Map(),
+			tools: new Map(),
+		};
+		const consumer_collision = {
+			path: '<inline:my-pi-telemetry>',
+			commands: new Map(),
+			tools: new Map(),
+		};
 		const result = override({
 			extensions: [
 				{ path: '/user', commands: new Map(), tools: new Map() },
-				{ path: '<inline:2>', commands: new Map(), tools: new Map() },
-				{ path: '<inline:1>', commands: new Map(), tools: new Map() },
+				{
+					path: '<inline:my-pi-mcp>',
+					commands: new Map(),
+					tools: new Map(),
+				},
+				managed_telemetry,
+				consumer_collision,
 			],
 		} as Parameters<typeof override>[0]);
 
-		expect(
-			result.extensions.map((extension) => extension.path),
-		).toEqual(['<inline:1>', '<inline:2>', '/user']);
+		expect(result.extensions).toEqual([
+			managed_telemetry,
+			expect.objectContaining({ path: '<inline:my-pi-mcp>' }),
+			expect.objectContaining({ path: '/user' }),
+			consumer_collision,
+		]);
 	});
 });

--- a/src/api/builtin-extensions.ts
+++ b/src/api/builtin-extensions.ts
@@ -127,27 +127,23 @@ export function create_lazy_telemetry_extension(options: {
 }
 
 export function create_extensions_override(
-	managed_inline_paths: string[],
+	managed_extension_paths: readonly string[],
 ): (base: LoadExtensionsResult) => LoadExtensionsResult {
-	const managed_paths = new Set(managed_inline_paths);
 	return (base) => {
-		const managed = new Map(
-			base.extensions.map((extension) => [extension.path, extension]),
-		);
-		const ordered_managed = managed_inline_paths
-			.map((path) => managed.get(path))
-			.filter(
-				(
-					extension,
-				): extension is LoadExtensionsResult['extensions'][number] =>
-					Boolean(extension),
-			);
-		const others = base.extensions.filter(
-			(extension) => !managed_paths.has(extension.path),
+		// Pi names inline extensions but still loads discovered paths first.
+		// Move only the first matching managed instance to preserve precedence.
+		const remaining = [...base.extensions];
+		const ordered_managed = managed_extension_paths.flatMap(
+			(path) => {
+				const index = remaining.findIndex(
+					(extension) => extension.path === path,
+				);
+				return index === -1 ? [] : remaining.splice(index, 1);
+			},
 		);
 		return {
 			...base,
-			extensions: [...ordered_managed, ...others],
+			extensions: [...ordered_managed, ...remaining],
 		};
 	};
 }

--- a/src/api/builtin-extensions.ts
+++ b/src/api/builtin-extensions.ts
@@ -1,5 +1,6 @@
 import type {
 	ExtensionFactory,
+	InlineExtension,
 	LoadExtensionsResult,
 } from '@earendil-works/pi-coding-agent';
 import { existsSync } from 'node:fs';
@@ -26,6 +27,23 @@ export const PACKAGE_THEME_DIR = resolve(
 	dirname(require.resolve('@spences10/pi-themes/package.json')),
 	'themes',
 );
+
+export const MANAGED_INLINE_EXTENSION_NAME_PREFIX = 'my-pi-';
+
+export function assert_unreserved_inline_extension_names(
+	extensions: readonly InlineExtension[],
+): void {
+	for (const extension of extensions) {
+		if (
+			typeof extension !== 'function' &&
+			extension.name.startsWith(MANAGED_INLINE_EXTENSION_NAME_PREFIX)
+		) {
+			throw new Error(
+				`Inline extension name "${extension.name}" is reserved for my-pi managed extensions; choose a name that does not start with "${MANAGED_INLINE_EXTENSION_NAME_PREFIX}".`,
+			);
+		}
+	}
+}
 
 export function get_force_disabled_builtins(
 	options: Pick<CreateMyPiOptions, 'runtime_mode'> &

--- a/src/api/options.ts
+++ b/src/api/options.ts
@@ -22,6 +22,7 @@ export interface CreateMyPiOptions extends BuiltinExtensionOptions {
 	cwd?: string;
 	agent_dir?: string;
 	extensions?: string[];
+	/** Named wrappers must not use the reserved `my-pi-` prefix. */
 	extensionFactories?: InlineExtension[];
 	runtime_mode?: MyPiRuntimeMode;
 	telemetry?: boolean;

--- a/src/api/options.ts
+++ b/src/api/options.ts
@@ -1,6 +1,6 @@
 import type {
 	CreateAgentSessionFromServicesOptions,
-	ExtensionFactory,
+	InlineExtension,
 } from '@earendil-works/pi-coding-agent';
 import type { BuiltinExtensionOptionName } from '../extensions/builtin-registry.js';
 
@@ -22,7 +22,7 @@ export interface CreateMyPiOptions extends BuiltinExtensionOptions {
 	cwd?: string;
 	agent_dir?: string;
 	extensions?: string[];
-	extensionFactories?: ExtensionFactory[];
+	extensionFactories?: InlineExtension[];
 	runtime_mode?: MyPiRuntimeMode;
 	telemetry?: boolean;
 	telemetry_db_path?: string;


### PR DESCRIPTION
## Summary

- wrap my-pi-managed factories with upstream Pi 0.80.10 named `InlineExtension` values for descriptive startup labels
- accept and re-export `InlineExtension` for programmatic consumers while preserving bare factory compatibility
- reserve the `my-pi-` prefix and reject consumer collisions before environment mutation, extension loading, or silent runner precedence
- retain the local extension override only for managed precedence
- document programmatic naming rules and add a root `my-pi` patch Changeset with exactly fifteen words

Closes #289

## Validation

- `pnpm exec vp check src/api.ts src/api/options.ts src/api.test.ts src/api/builtin-extensions.ts src/api/builtin-extensions.test.ts` — passed
- `pnpm exec vp test src/api.test.ts src/api/builtin-extensions.test.ts` — 2 files, 26 tests passed
- `pnpm run build` — passed
- `pnpm run check` — passed; formatting, lint, type checks, docs, boundaries, and package checks completed
- `MY_PI_RUNTIME_MODE=interactive pnpm run test` — root 37 files/153 tests plus every package suite passed
- explicit Changeset whitespace word-count script — passed with 15 words
- changed-file `lsp_diagnostics_many` — attempted after final edits; TypeScript language server could not resolve a workspace TypeScript installation
- `git diff --check` — passed
- independent read-only follow-up review — approved

The first unsanitized validation run inherited `MY_PI_RUNTIME_MODE=print` from the agent process and failed one pi-mcp active-tool assertion. Interactive-mode reruns, matching the startup-display target, passed all 65 pi-mcp tests and the complete suite.

## Remaining risks

- Changed-file LSP diagnostics were unavailable in this workspace; `pnpm run build` and `pnpm run check` supplied successful TypeScript validation instead.