### PR TITLE
refactor: share GitHub remote parsing

### DIFF
--- a/.changeset/tidy-remotes-share.md
+++ b/.changeset/tidy-remotes-share.md
@@ -1,0 +1,9 @@
+---
+'@spences10/pi-git-remote': patch
+'@spences10/pi-mcp': patch
+'@spences10/pi-skills': patch
+'my-pi': patch
+---
+
+Share GitHub remote parsing across MCP policies and skill contexts
+while preserving package-specific matching behavior.

--- a/README.md
+++ b/README.md
@@ -183,12 +183,13 @@ Full package list here:
 | [`@spences10/pi-themes`](./packages/pi-themes/README.md)                           | Bundled theme pack for Pi                                  |
 
 Shared helper packages such as `@spences10/pi-child-env`,
-`@spences10/pi-footer`, `@spences10/pi-project-trust`,
-`@spences10/pi-settings`, `@spences10/pi-skill-importer`,
-`@spences10/pi-sqlite-core`, and `@spences10/pi-tui-modal` are
-published as dependencies and are not packages to install via
-`pi install`. See [`docs/package-map.md`](./docs/package-map.md) for
-the authoritative classification.
+`@spences10/pi-footer`, `@spences10/pi-git-remote`,
+`@spences10/pi-project-trust`, `@spences10/pi-settings`,
+`@spences10/pi-skill-importer`, `@spences10/pi-sqlite-core`, and
+`@spences10/pi-tui-modal` are published as dependencies and are not
+packages to install via `pi install`. See
+[`docs/package-map.md`](./docs/package-map.md) for the authoritative
+classification.
 
 Maintainers publish from GitHub Actions with npm trusted publishing;
 see [`docs/releases.md`](./docs/releases.md) for the workflow and the

--- a/docs/package-map.md
+++ b/docs/package-map.md
@@ -36,6 +36,7 @@ with `pi install` directly:
 
 - `@spences10/pi-child-env`
 - `@spences10/pi-footer`
+- `@spences10/pi-git-remote`
 - `@spences10/pi-project-trust`
 - `@spences10/pi-settings`
 - `@spences10/pi-skill-importer`

--- a/packages/pi-git-remote/CHANGELOG.md
+++ b/packages/pi-git-remote/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @spences10/pi-git-remote
+
+## 0.0.1
+
+### Patch Changes
+
+- Add shared GitHub remote parsing helpers for context-aware Pi
+  packages.

--- a/packages/pi-git-remote/README.md
+++ b/packages/pi-git-remote/README.md
@@ -1,0 +1,25 @@
+# @spences10/pi-git-remote
+
+Shared GitHub remote parsing helpers for context-aware Pi packages.
+This support package is published for other `@spences10/pi-*` packages
+and is not a Pi extension users install directly.
+
+## API
+
+- `parse_github_repo(remote)` normalizes supported GitHub SSH and
+  HTTPS remote URLs to a lowercase `owner/repo` identifier.
+- `get_github_repos(cwd)` reads the repository's Git remotes, returns
+  unique GitHub `owner/repo` identifiers, and returns an empty array
+  when Git inspection fails.
+
+Supported remote forms are `git@github.com:owner/repo.git`,
+`https://github.com/owner/repo.git`, and
+`ssh://git@github.com/owner/repo.git`.
+
+## Development
+
+```bash
+pnpm --filter @spences10/pi-git-remote run check
+pnpm --filter @spences10/pi-git-remote run test
+pnpm --filter @spences10/pi-git-remote run build
+```

--- a/packages/pi-git-remote/package.json
+++ b/packages/pi-git-remote/package.json
@@ -7,11 +7,12 @@
 		"github",
 		"pi"
 	],
+	"homepage": "https://github.com/spences10/my-pi/tree/main/packages/pi-git-remote#readme",
 	"license": "MIT",
 	"author": "Scott Spence <me@scottspence.com>",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/scottspence/my-pi.git",
+		"url": "git+https://github.com/spences10/my-pi.git",
 		"directory": "packages/pi-git-remote"
 	},
 	"files": [

--- a/packages/pi-git-remote/package.json
+++ b/packages/pi-git-remote/package.json
@@ -1,20 +1,18 @@
 {
-	"name": "@spences10/pi-skills",
-	"version": "0.0.34",
-	"description": "Agent Skills management for Pi with profiles, enablement rules, GitHub search/install, and update flows",
+	"name": "@spences10/pi-git-remote",
+	"version": "0.0.1",
+	"description": "Shared GitHub remote parsing helpers for context-aware Pi packages",
 	"keywords": [
-		"agent-skills",
-		"pi",
-		"pi-package",
-		"skills"
+		"git",
+		"github",
+		"pi"
 	],
-	"homepage": "https://github.com/spences10/my-pi/tree/main/packages/pi-skills#readme",
 	"license": "MIT",
 	"author": "Scott Spence <me@scottspence.com>",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/spences10/my-pi.git",
-		"directory": "packages/pi-skills"
+		"url": "git+https://github.com/scottspence/my-pi.git",
+		"directory": "packages/pi-git-remote"
 	},
 	"files": [
 		"dist",
@@ -29,9 +27,6 @@
 			"default": "./dist/index.js"
 		}
 	},
-	"publishConfig": {
-		"access": "public"
-	},
 	"scripts": {
 		"build": "pnpm --filter \"$npm_package_name^...\" run build:self && pnpm run build:self",
 		"build:self": "vp exec tsc -p tsconfig.build.json",
@@ -42,30 +37,12 @@
 		"coverage:self": "vp exec vitest run --coverage",
 		"coverage": "pnpm --filter \"$npm_package_name^...\" run build:self && pnpm run coverage:self"
 	},
-	"dependencies": {
-		"@spences10/pi-git-remote": "workspace:*",
-		"@spences10/pi-settings": "workspace:*",
-		"@spences10/pi-skill-importer": "workspace:*",
-		"@spences10/pi-tui-modal": "workspace:*"
-	},
 	"devDependencies": {
-		"@earendil-works/pi-coding-agent": "catalog:",
-		"@earendil-works/pi-tui": "catalog:",
 		"@types/node": "catalog:",
 		"typescript": "catalog:",
 		"vitest": "catalog:"
 	},
-	"peerDependencies": {
-		"@earendil-works/pi-coding-agent": "*",
-		"@earendil-works/pi-tui": "*"
-	},
 	"engines": {
 		"node": ">=24.15.0"
-	},
-	"pi": {
-		"extensions": [
-			"./dist/index.js"
-		],
-		"image": "https://raw.githubusercontent.com/spences10/my-pi/main/assets/pi-package-preview.png"
 	}
 }

--- a/packages/pi-git-remote/src/index.test.ts
+++ b/packages/pi-git-remote/src/index.test.ts
@@ -1,0 +1,76 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { get_github_repos, parse_github_repo } from './index.js';
+
+const dirs: string[] = [];
+
+function tmp_dir(): string {
+	const dir = join(
+		tmpdir(),
+		`my-pi-git-remote-${Date.now()}-${Math.random()}`,
+	);
+	mkdirSync(dir, { recursive: true });
+	dirs.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of dirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe('parse_github_repo', () => {
+	it.each([
+		['git@github.com:Owner/Repo.git', 'owner/repo'],
+		['https://github.com/Owner/Repo.git', 'owner/repo'],
+		['ssh://git@github.com/Owner/Repo.git', 'owner/repo'],
+	])('parses supported GitHub remote %s', (remote, expected) => {
+		expect(parse_github_repo(remote)).toBe(expected);
+	});
+
+	it.each([
+		'http://github.com/owner/repo.git',
+		'git://github.com/owner/repo.git',
+		'https://gitlab.com/owner/repo.git',
+		'owner/repo',
+	])('ignores unsupported remote %s', (remote) => {
+		expect(parse_github_repo(remote)).toBeUndefined();
+	});
+});
+
+describe('get_github_repos', () => {
+	it('deduplicates GitHub fetch and push remotes and ignores other hosts', () => {
+		const cwd = tmp_dir();
+		execFileSync('git', ['init'], { cwd, stdio: 'ignore' });
+		execFileSync(
+			'git',
+			['remote', 'add', 'origin', 'git@github.com:Owner/Repo.git'],
+			{ cwd, stdio: 'ignore' },
+		);
+		execFileSync(
+			'git',
+			[
+				'remote',
+				'add',
+				'mirror',
+				'https://github.com/owner/repo.git',
+			],
+			{ cwd, stdio: 'ignore' },
+		);
+		execFileSync(
+			'git',
+			['remote', 'add', 'other', 'https://gitlab.com/owner/repo.git'],
+			{ cwd, stdio: 'ignore' },
+		);
+
+		expect(get_github_repos(cwd)).toEqual(['owner/repo']);
+	});
+
+	it('returns an empty list when git remote inspection fails', () => {
+		expect(get_github_repos(join(tmp_dir(), 'missing'))).toEqual([]);
+	});
+});

--- a/packages/pi-git-remote/src/index.ts
+++ b/packages/pi-git-remote/src/index.ts
@@ -1,0 +1,35 @@
+import { execFileSync } from 'node:child_process';
+
+export function parse_github_repo(
+	remote: string,
+): string | undefined {
+	const trimmed = remote.trim().replace(/\.git$/, '');
+	const match =
+		/^git@github\.com:([^/]+)\/(.+)$/.exec(trimmed) ??
+		/^https:\/\/github\.com\/([^/]+)\/(.+)$/.exec(trimmed) ??
+		/^ssh:\/\/git@github\.com\/([^/]+)\/(.+)$/.exec(trimmed);
+	if (!match) return undefined;
+	return `${match[1]}/${match[2]}`.toLowerCase();
+}
+
+export function get_github_repos(cwd: string): string[] {
+	try {
+		const output = execFileSync('git', ['remote', '-v'], {
+			cwd,
+			encoding: 'utf-8',
+			stdio: ['ignore', 'pipe', 'ignore'],
+		});
+		return [
+			...new Set(
+				output
+					.split('\n')
+					.map((line) => line.trim().split(/\s+/)[1])
+					.filter((remote): remote is string => Boolean(remote))
+					.map(parse_github_repo)
+					.filter((repo): repo is string => Boolean(repo)),
+			),
+		];
+	} catch {
+		return [];
+	}
+}

--- a/packages/pi-git-remote/tsconfig.build.json
+++ b/packages/pi-git-remote/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./dist",
+		"declaration": true,
+		"sourceMap": true
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["src/**/*.test.ts", "node_modules", "dist"]
+}

--- a/packages/pi-git-remote/tsconfig.json
+++ b/packages/pi-git-remote/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"strict": true,
+		"esModuleInterop": true,
+		"allowSyntheticDefaultImports": true,
+		"skipLibCheck": true,
+		"types": ["node", "vitest/globals"]
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules"]
+}

--- a/packages/pi-mcp/package.json
+++ b/packages/pi-mcp/package.json
@@ -45,6 +45,7 @@
 	"dependencies": {
 		"@spences10/pi-child-env": "workspace:*",
 		"@spences10/pi-context": "workspace:*",
+		"@spences10/pi-git-remote": "workspace:*",
 		"@spences10/pi-project-trust": "workspace:*",
 		"@spences10/pi-settings": "workspace:*",
 		"@spences10/pi-tui-modal": "workspace:*"

--- a/packages/pi-mcp/src/config.ts
+++ b/packages/pi-mcp/src/config.ts
@@ -1,14 +1,11 @@
+import { get_github_repos } from '@spences10/pi-git-remote';
 import { createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 import {
 	global_mcp_config_path,
 	project_mcp_config_path,
 } from './config/paths.js';
-import {
-	get_github_repos,
-	load_mcp_policy,
-	policy_matches,
-} from './config/policy.js';
+import { load_mcp_policy, policy_matches } from './config/policy.js';
 import {
 	read_config,
 	read_config_file,

--- a/packages/pi-mcp/src/config/policy.ts
+++ b/packages/pi-mcp/src/config/policy.ts
@@ -1,5 +1,4 @@
 import { read_settings } from '@spences10/pi-settings';
-import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { isAbsolute, relative, resolve, sep } from 'node:path';
 import {
@@ -36,38 +35,6 @@ function as_string_array(
 		);
 	}
 	return values.map((entry) => entry.trim());
-}
-
-function parse_github_repo(remote: string): string | undefined {
-	const trimmed = remote.trim().replace(/\.git$/, '');
-	const match =
-		/^git@github\.com:([^/]+)\/(.+)$/.exec(trimmed) ??
-		/^https:\/\/github\.com\/([^/]+)\/(.+)$/.exec(trimmed) ??
-		/^ssh:\/\/git@github\.com\/([^/]+)\/(.+)$/.exec(trimmed);
-	if (!match) return undefined;
-	return `${match[1]}/${match[2]}`.toLowerCase();
-}
-
-export function get_github_repos(cwd: string): string[] {
-	try {
-		const output = execFileSync('git', ['remote', '-v'], {
-			cwd,
-			encoding: 'utf-8',
-			stdio: ['ignore', 'pipe', 'ignore'],
-		});
-		return [
-			...new Set(
-				output
-					.split('\n')
-					.map((line) => line.trim().split(/\s+/)[1])
-					.filter((remote): remote is string => Boolean(remote))
-					.map(parse_github_repo)
-					.filter((repo): repo is string => Boolean(repo)),
-			),
-		];
-	} catch {
-		return [];
-	}
 }
 
 export function load_mcp_policy(

--- a/packages/pi-skills/src/manager.ts
+++ b/packages/pi-skills/src/manager.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process';
+import { get_github_repos } from '@spences10/pi-git-remote';
 import { existsSync, rmSync } from 'node:fs';
 import { dirname, isAbsolute, relative, resolve } from 'node:path';
 import {
@@ -154,38 +154,6 @@ function string_values(
 ): string[] {
 	if (!value) return [];
 	return Array.isArray(value) ? value : [value];
-}
-
-function parse_github_repo(remote: string): string | undefined {
-	const trimmed = remote.trim().replace(/\.git$/, '');
-	const match =
-		/^git@github\.com:([^/]+)\/(.+)$/.exec(trimmed) ??
-		/^https:\/\/github\.com\/([^/]+)\/(.+)$/.exec(trimmed) ??
-		/^ssh:\/\/git@github\.com\/([^/]+)\/(.+)$/.exec(trimmed);
-	if (!match) return undefined;
-	return `${match[1]}/${match[2]}`.toLowerCase();
-}
-
-function get_github_repos(cwd: string): string[] {
-	try {
-		const output = execFileSync('git', ['remote', '-v'], {
-			cwd,
-			encoding: 'utf-8',
-			stdio: ['ignore', 'pipe', 'ignore'],
-		});
-		return [
-			...new Set(
-				output
-					.split('\n')
-					.map((line) => line.trim().split(/\s+/)[1])
-					.filter((remote): remote is string => Boolean(remote))
-					.map(parse_github_repo)
-					.filter((repo): repo is string => Boolean(repo)),
-			),
-		];
-	} catch {
-		return [];
-	}
 }
 
 export function create_skills_manager(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,6 +477,18 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
+  packages/pi-git-remote:
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.5
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.9.5)(@vitest/browser-playwright@4.1.10)(@vitest/browser-preview@4.1.10)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+
   packages/pi-git-ui:
     dependencies:
       '@spences10/pi-tui-modal':
@@ -550,6 +562,9 @@ importers:
       '@spences10/pi-context':
         specifier: workspace:*
         version: link:../pi-context
+      '@spences10/pi-git-remote':
+        specifier: workspace:*
+        version: link:../pi-git-remote
       '@spences10/pi-project-trust':
         specifier: workspace:*
         version: link:../pi-project-trust
@@ -738,6 +753,9 @@ importers:
 
   packages/pi-skills:
     dependencies:
+      '@spences10/pi-git-remote':
+        specifier: workspace:*
+        version: link:../pi-git-remote
       '@spences10/pi-settings':
         specifier: workspace:*
         version: link:../pi-settings


### PR DESCRIPTION
## Summary

- add `@spences10/pi-git-remote` as a focused shared support package with direct regression coverage
- reuse the shared helpers from pi-mcp and pi-skills while retaining local policy/profile matching
- add package documentation, release metadata, lockfile wiring, and patch Changesets for all affected publishable packages

Closes #178

## Validation

- `pnpm --filter @spences10/pi-git-remote run check`
- `pnpm --filter @spences10/pi-git-remote run test` (9 tests)
- `pnpm --filter @spences10/pi-git-remote run build`
- `pnpm --filter @spences10/pi-mcp run check`
- `MY_PI_RUNTIME_MODE=interactive pnpm --filter @spences10/pi-mcp run test` (65 tests)
- `pnpm --filter @spences10/pi-mcp run build`
- `pnpm --filter @spences10/pi-skills run check`
- `pnpm --filter @spences10/pi-skills run test` (66 tests)
- `pnpm --filter @spences10/pi-skills run build`
- `pnpm run check`
- `MY_PI_RUNTIME_MODE=interactive pnpm test`
- changed-file `typescript-language-server --stdio` diagnostics: 5 files, 0 diagnostics
- `pnpm changeset status`: patch bumps for pi-git-remote, pi-mcp, pi-skills, and my-pi
- Changeset prose explicitly verified as exactly 15 whitespace-separated words
- `git diff --check`

## Review

- independent read-only peer review: approved with no blocking findings
- follow-up release-metadata review findings resolved in `ed823e5`

## Remaining risks

- None identified.