### PR TITLE
fix: harden Team Mode coordination hygiene

### DIFF
--- a/.changeset/team-coordination-hygiene.md
+++ b/.changeset/team-coordination-hygiene.md
@@ -1,0 +1,6 @@
+---
+'@spences10/pi-team-mode': patch
+---
+
+Improve group targeting, copyable session identifiers, and safe
+retention cleanup across durable peer coordination records.

--- a/packages/pi-team-mode/README.md
+++ b/packages/pi-team-mode/README.md
@@ -58,6 +58,11 @@ message into a new artifact. For intentionally large handoffs, senders
 should create a Team Mode artifact, send its id, and recipients should
 retrieve that referenced artifact.
 
+Default session lists begin each row with a directly copyable id
+target. The compact target expands past twelve characters when needed
+to avoid collisions with any registered session, including offline
+history. Full mode still displays complete ids.
+
 Coordination state is stored in:
 
 ```text
@@ -150,17 +155,48 @@ spawn, supervise, or attach to them.
 ## Groups and standby sessions
 
 Groups organize independently running sessions without changing who
-may talk to whom. A session can advertise an intent such as
+may talk to whom. Group targets resolve by exact group id first. A
+name resolves only when it identifies one group in the caller's
+current working directory; ambiguous names fail instead of selecting
+the most recent group. A session can advertise an intent such as
 standby/reviewer through its prompt, allowing another session to
 discover and coordinate with it. Opening, closing, naming, and
 isolating those Pi processes remains the user's responsibility.
+
+## Retention and cleanup
+
+Team Mode runs safe cleanup after session registration and
+stale-process detection. The default retention window is 30 days. Set
+`MY_PI_TEAM_RETENTION_DAYS` to a positive number of days, or set it to
+`0`/`off` to disable startup cleanup.
+
+- events older than the window are deleted;
+- artifacts whose last update is older than the window are deleted,
+  unless an unacknowledged message still names their artifact id;
+- expired or historical messages are deleted only after every receipt
+  is acknowledged, and their receipts are deleted with them;
+- unacknowledged messages and receipts remain durable even after TTL
+  expiry;
+- groups older than the window are deleted only when they have no
+  active or recently offline member session and no retained group
+  message;
+- offline sessions older than the window are deleted only after no
+  retained message, receipt, artifact, group membership, or dormant
+  runtime row refers to them; online/idle/running/blocked sessions are
+  never pruned.
+
+Cleanup intentionally preserves active peer state and does not create,
+wake, supervise, or attach to any process. Invalid retention settings
+fall back to 30 days. The database cleanup method also accepts an
+explicit retention window for maintenance and tests.
 
 ## Database compatibility
 
 Released numbered migrations are immutable. Schema version 4 contains
 dormant persistent-runtime tables from an earlier experiment so
 databases upgraded by version `0.0.48` continue to open safely.
-Peer-only Team Mode does not read or write those tables.
+Peer-only Team Mode never operates those runtimes; cleanup only checks
+for dormant references so their historical sessions remain compatible.
 
 ## Development
 

--- a/packages/pi-team-mode/README.md
+++ b/packages/pi-team-mode/README.md
@@ -165,10 +165,16 @@ isolating those Pi processes remains the user's responsibility.
 
 ## Retention and cleanup
 
-Team Mode runs safe cleanup after session registration and
-stale-process detection. The default retention window is 30 days. Set
-`MY_PI_TEAM_RETENTION_DAYS` to a positive number of days, or set it to
-`0`/`off` to disable startup cleanup.
+Team Mode messages and artifacts are intentional coordination records,
+unlike derived context or observability data. Team Mode therefore does
+not delete coordination history at startup by default. Startup cleanup
+runs after session registration and stale-process detection only when
+`MY_PI_TEAM_RETENTION_DAYS` contains a valid positive number of days.
+Unset or blank values, `0`, `off`, `false`, `disabled`, negative
+values, and invalid values all disable startup cleanup rather than
+selecting a destructive fallback.
+
+When cleanup is explicitly enabled or invoked:
 
 - events older than the window are deleted;
 - artifacts whose last update is older than the window are deleted,
@@ -186,9 +192,11 @@ stale-process detection. The default retention window is 30 days. Set
   never pruned.
 
 Cleanup intentionally preserves active peer state and does not create,
-wake, supervise, or attach to any process. Invalid retention settings
-fall back to 30 days. The database cleanup method also accepts an
-explicit retention window for maintenance and tests.
+wake, supervise, or attach to any process. For intentional
+maintenance, calling the database's `prune_historical_data()` API
+without options uses a 30-day retention window; pass `retention_ms`
+and optionally `reference_time` to choose an explicit window. Merely
+starting Team Mode never applies that manual default.
 
 ## Database compatibility
 

--- a/packages/pi-team-mode/src/commands/coordination-commands.ts
+++ b/packages/pi-team-mode/src/commands/coordination-commands.ts
@@ -16,8 +16,18 @@ export async function handle_sessions(
 	deps: TeamCommandDeps,
 ): Promise<void> {
 	deps.coordination_db.mark_stale_sessions_offline();
-	const sessions = deps.coordination_db.list_sessions();
-	deps.ctx.ui.notify(format_sessions(sessions), 'info');
+	const all_sessions = deps.coordination_db.list_sessions({
+		include_offline: true,
+	});
+	const sessions = all_sessions.filter(
+		(session) => session.status !== 'offline',
+	);
+	deps.ctx.ui.notify(
+		format_sessions(sessions, {
+			target_ids: all_sessions.map((session) => session.session_id),
+		}),
+		'info',
+	);
 }
 
 export async function handle_session_command(
@@ -129,7 +139,9 @@ export async function handle_group_command(
 		const [group_target, alias] = tail;
 		if (!group_target)
 			throw new Error('Usage: /team group join <group> [alias]');
-		const group = deps.coordination_db.get_group(group_target);
+		const group = deps.coordination_db.get_group(group_target, {
+			cwd: deps.ctx.cwd,
+		});
 		if (!group) throw new Error(`Unknown group: ${group_target}`);
 		deps.coordination_db.add_group_member({
 			group_id: group.group_id,
@@ -145,14 +157,17 @@ export async function handle_group_command(
 			throw new Error('Usage: /team group send <group> <message>');
 		const from_session_id = require_session_id(deps);
 		const recipients = deps.coordination_db
-			.list_group_members(group_target)
+			.list_group_members(group_target, { cwd: deps.ctx.cwd })
 			.filter((member) => member.session_id !== from_session_id)
 			.map((member) => member.session_id);
-		const message = deps.coordination_db.send_to_group({
-			from_session_id,
-			target: group_target,
-			body: message_parts.join(' '),
-		});
+		const message = deps.coordination_db.send_to_group(
+			{
+				from_session_id,
+				target: group_target,
+				body: message_parts.join(' '),
+			},
+			{ cwd: deps.ctx.cwd },
+		);
 		await deps.notify_coordination_messages(
 			recipients,
 			message.message_id,

--- a/packages/pi-team-mode/src/coordination-formatting.test.ts
+++ b/packages/pi-team-mode/src/coordination-formatting.test.ts
@@ -43,8 +43,9 @@ const inbox_message: CoordinationInboxMessage = {
 };
 
 describe('coordination formatting', () => {
-	it('truncates session ids by default and prints full ids on request', () => {
-		expect(format_sessions([session])).toContain('019f0f71-967…');
+	it('prints a copyable session target by default and full ids on request', () => {
+		expect(format_sessions([session])).toContain('019f0f71-967');
+		expect(format_sessions([session])).not.toContain('019f0f71-967…');
 		expect(format_sessions([session])).not.toContain(
 			'019f0f71-967e-7aed-853c-94ac29fbe7b6',
 		);
@@ -52,6 +53,18 @@ describe('coordination formatting', () => {
 		expect(format_sessions([session], { full_ids: true })).toContain(
 			'019f0f71-967e-7aed-853c-94ac29fbe7b6',
 		);
+	});
+
+	it('expands colliding compact targets until each is unambiguous', () => {
+		const other_id = '019f0f71-967f-7aed-853c-94ac29fbe7b6';
+		const text = format_sessions([
+			session,
+			{ ...session, session_id: other_id },
+		]);
+
+		expect(text).toContain(session.session_id.slice(0, 13));
+		expect(text).toContain(other_id.slice(0, 13));
+		expect(text).not.toContain('…');
 	});
 
 	it('labels registered standby sessions', () => {

--- a/packages/pi-team-mode/src/coordination-formatting.ts
+++ b/packages/pi-team-mode/src/coordination-formatting.ts
@@ -17,6 +17,23 @@ function short_id(id: string): string {
 	return id.length > 12 ? `${id.slice(0, 12)}…` : id;
 }
 
+function copyable_session_target(
+	session_id: string,
+	all_session_ids: string[],
+): string {
+	let length = Math.min(12, session_id.length);
+	while (
+		length < session_id.length &&
+		all_session_ids.some(
+			(candidate) =>
+				candidate !== session_id &&
+				candidate.startsWith(session_id.slice(0, length)),
+		)
+	)
+		length += 1;
+	return session_id.slice(0, length);
+}
+
 export const COMPACT_BODY_LIMIT = 240;
 
 interface CompactBody {
@@ -44,14 +61,17 @@ function compact_body(body: string): CompactBody {
 
 export function format_sessions(
 	sessions: CoordinationSession[],
-	options: { full_ids?: boolean } = {},
+	options: { full_ids?: boolean; target_ids?: string[] } = {},
 ): string {
 	if (sessions.length === 0) return 'No registered sessions.';
+	const target_ids =
+		options.target_ids ??
+		sessions.map((session) => session.session_id);
 	return sessions
 		.map((session) => {
 			const id = options.full_ids
 				? session.session_id
-				: short_id(session.session_id);
+				: copyable_session_target(session.session_id, target_ids);
 			const name = session.agent_name ? ` ${session.agent_name}` : '';
 			const alias = session.session_alias
 				? ` (${session.session_alias})`

--- a/packages/pi-team-mode/src/db/index.test.ts
+++ b/packages/pi-team-mode/src/db/index.test.ts
@@ -443,6 +443,179 @@ describe('TeamDatabase coordination store', () => {
 		}
 	});
 
+	it('resolves group ids exactly and same-name groups only within the caller cwd', async () => {
+		const db = await TeamDatabase.open(tmp_db());
+		try {
+			db.register_session({ session_id: 'lead-a', cwd: '/repo-a' });
+			db.register_session({ session_id: 'lead-b', cwd: '/repo-b' });
+			const group_a = db.create_group({
+				name: 'review',
+				cwd: '/repo-a',
+				created_by_session_id: 'lead-a',
+			});
+			const group_b = db.create_group({
+				name: 'review',
+				cwd: '/repo-b',
+				created_by_session_id: 'lead-b',
+			});
+
+			expect(
+				db.get_group('review', { cwd: '/repo-a' }),
+			).toMatchObject({
+				group_id: group_a.group_id,
+			});
+			expect(
+				db.get_group('review', { cwd: '/repo-b' }),
+			).toMatchObject({
+				group_id: group_b.group_id,
+			});
+			expect(
+				db.get_group(group_a.group_id, { cwd: '/repo-b' }),
+			).toMatchObject({ group_id: group_a.group_id });
+			expect(() => db.get_group('review')).toThrow(
+				/Ambiguous group target: review/,
+			);
+		} finally {
+			db.close();
+		}
+	});
+
+	it('keeps an old group while a member session is active or recently offline', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+		const db = await TeamDatabase.open(tmp_db());
+		try {
+			db.register_session({ session_id: 'member', cwd: '/repo' });
+			const group = db.create_group({
+				name: 'long-running',
+				cwd: '/repo',
+				created_by_session_id: 'member',
+			});
+
+			vi.setSystemTime(new Date('2026-02-01T00:00:00.000Z'));
+			db.mark_session_status('member', 'offline');
+			db.prune_historical_data();
+
+			expect(db.get_group(group.group_id)).toBeDefined();
+			expect(db.get_session('member')).toBeDefined();
+		} finally {
+			db.close();
+			vi.useRealTimers();
+		}
+	});
+
+	it('prunes historical coordination rows without deleting active sessions or unacknowledged messages', async () => {
+		const db = await TeamDatabase.open(tmp_db());
+		try {
+			for (const session_id of [
+				'active',
+				'group-owner',
+				'artifact-owner',
+				'ack-sender',
+				'ack-recipient',
+				'pending-sender',
+				'pending-recipient',
+			])
+				db.register_session({ session_id, cwd: '/repo' });
+
+			const historical_group = db.create_group({
+				name: 'historical',
+				cwd: '/repo',
+				created_by_session_id: 'group-owner',
+			});
+			const active_group = db.create_group({
+				name: 'active-group',
+				cwd: '/repo',
+				created_by_session_id: 'active',
+			});
+			const artifact = db.create_artifact({
+				kind: 'handoff',
+				owner_session_id: 'artifact-owner',
+				cwd: '/repo',
+				title: 'Historical handoff',
+				summary: 'Already completed',
+				body: 'Old coordination context',
+			});
+			const pending_artifact = db.create_artifact({
+				kind: 'evidence',
+				owner_session_id: 'pending-sender',
+				cwd: '/repo',
+				title: 'Pending evidence',
+				summary: 'Awaiting acknowledgement',
+				body: 'Evidence needed to process the pending message',
+			});
+			const acknowledged = db.send_message({
+				from_session_id: 'ack-sender',
+				to_session_ids: ['ack-recipient'],
+				scope: 'session',
+				target: 'ack-recipient',
+				body: 'complete',
+				ttl_ms: 1,
+				requires_ack: true,
+			});
+			db.mark_messages_acknowledged('ack-recipient', [
+				acknowledged.message_id,
+			]);
+			const pending = db.send_message({
+				from_session_id: 'pending-sender',
+				to_session_ids: ['pending-recipient'],
+				scope: 'session',
+				target: 'pending-recipient',
+				body: `still pending; see ${pending_artifact.artifact_id}`,
+				ttl_ms: 1,
+				requires_ack: true,
+			});
+			db.insert_event({ type: 'historical-test' });
+			for (const session_id of [
+				'group-owner',
+				'artifact-owner',
+				'ack-sender',
+				'ack-recipient',
+				'pending-sender',
+				'pending-recipient',
+			])
+				db.mark_session_status(session_id, 'offline');
+
+			const result = db.prune_historical_data({
+				retention_ms: 0,
+				reference_time: new Date(Date.now() + 10_000),
+			});
+
+			expect(result).toMatchObject({
+				artifacts: 1,
+				groups: 1,
+				messages: 1,
+				receipts: 1,
+				sessions: 4,
+			});
+			expect(result.events).toBeGreaterThanOrEqual(3);
+			expect(db.get_artifact(artifact.artifact_id)).toBeUndefined();
+			expect(
+				db.get_artifact(pending_artifact.artifact_id),
+			).toBeDefined();
+			expect(db.get_group(historical_group.group_id)).toBeUndefined();
+			expect(db.get_group(active_group.group_id)).toBeDefined();
+			expect(db.get_session('active')).toMatchObject({
+				status: 'online',
+			});
+			expect(db.get_session('pending-sender')).toBeDefined();
+			expect(db.get_session('pending-recipient')).toBeDefined();
+			expect(
+				db.read_rows<{ message_id: string }>(
+					'SELECT message_id FROM messages',
+				),
+			).toEqual([{ message_id: pending.message_id }]);
+			expect(
+				db.read_rows<{ message_id: string }>(
+					'SELECT message_id FROM message_receipts',
+				),
+			).toEqual([{ message_id: pending.message_id }]);
+			expect(db.read_rows('SELECT * FROM events')).toEqual([]);
+		} finally {
+			db.close();
+		}
+	});
+
 	it('creates groups and sends group messages to independent sessions', async () => {
 		const db = await TeamDatabase.open(tmp_db());
 		try {

--- a/packages/pi-team-mode/src/db/index.test.ts
+++ b/packages/pi-team-mode/src/db/index.test.ts
@@ -480,7 +480,7 @@ describe('TeamDatabase coordination store', () => {
 		}
 	});
 
-	it('keeps an old group while a member session is active or recently offline', async () => {
+	it('uses a thirty-day manual default while keeping active or recently offline group members', async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
 		const db = await TeamDatabase.open(tmp_db());
@@ -491,11 +491,13 @@ describe('TeamDatabase coordination store', () => {
 				cwd: '/repo',
 				created_by_session_id: 'member',
 			});
+			db.insert_event({ type: 'manual-retention-test' });
 
 			vi.setSystemTime(new Date('2026-02-01T00:00:00.000Z'));
 			db.mark_session_status('member', 'offline');
-			db.prune_historical_data();
+			const result = db.prune_historical_data();
 
+			expect(result.events).toBeGreaterThan(0);
 			expect(db.get_group(group.group_id)).toBeDefined();
 			expect(db.get_session('member')).toBeDefined();
 		} finally {

--- a/packages/pi-team-mode/src/db/index.ts
+++ b/packages/pi-team-mode/src/db/index.ts
@@ -8,6 +8,7 @@ import { dirname } from 'node:path';
 
 import type { DatabaseSync, StatementSync } from 'node:sqlite';
 
+import { DEFAULT_COORDINATION_RETENTION_MS } from '../retention.js';
 import {
 	find_stale_sessions,
 	type ProcessAliveCheck,
@@ -25,6 +26,8 @@ import { prepare_statements } from './statements.js';
 import type {
 	ArtifactRow,
 	CoordinationArtifact,
+	CoordinationCleanupOptions,
+	CoordinationCleanupResult,
 	CoordinationArtifactInput,
 	CoordinationArtifactKind,
 	CoordinationGroup,
@@ -56,6 +59,8 @@ import {
 export { LATEST_TEAM_SCHEMA_VERSION } from './schema.js';
 export type {
 	CoordinationArtifact,
+	CoordinationCleanupOptions,
+	CoordinationCleanupResult,
 	CoordinationArtifactInput,
 	CoordinationArtifactKind,
 	CoordinationGroup,
@@ -316,7 +321,10 @@ export class TeamDatabase {
 		const group_id = `${input.name
 			.trim()
 			.toLowerCase()
-			.replace(/[^a-z0-9_.-]+/g, '-')}-${Date.now().toString(36)}`;
+			.replace(
+				/[^a-z0-9_.-]+/g,
+				'-',
+			)}-${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`;
 		this.write(() =>
 			this.statements.insert_group.run(
 				group_id,
@@ -339,15 +347,30 @@ export class TeamDatabase {
 		return this.get_group(group_id)!;
 	}
 
-	get_group(group_id_or_name: string): CoordinationGroup | undefined {
-		const row =
-			(this.statements.get_group.get(group_id_or_name) as
-				| GroupRow
-				| undefined) ??
-			(this.statements.find_group_by_name.get(group_id_or_name) as
-				| GroupRow
-				| undefined);
-		return row ? map_group(row) : undefined;
+	get_group(
+		group_id_or_name: string,
+		options: { cwd?: string } = {},
+	): CoordinationGroup | undefined {
+		const exact = this.statements.get_group.get(group_id_or_name) as
+			| GroupRow
+			| undefined;
+		if (exact) return map_group(exact);
+
+		const rows = (options.cwd
+			? this.statements.find_groups_by_name_cwd.all(
+					group_id_or_name,
+					options.cwd,
+				)
+			: this.statements.find_groups_by_name.all(
+					group_id_or_name,
+				)) as unknown as GroupRow[];
+		if (rows.length === 0) return undefined;
+		if (rows.length === 1) return map_group(rows[0]!);
+		throw new Error(
+			`Ambiguous group target: ${group_id_or_name}. Matching groups: ${rows
+				.map((row) => `${row.group_id} (${row.cwd ?? 'no cwd'})`)
+				.join(', ')}`,
+		);
 	}
 
 	list_groups(): CoordinationGroup[] {
@@ -381,8 +404,9 @@ export class TeamDatabase {
 
 	list_group_members(
 		group_id_or_name: string,
+		options: { cwd?: string } = {},
 	): CoordinationGroupMember[] {
-		const group = this.get_group(group_id_or_name);
+		const group = this.get_group(group_id_or_name, options);
 		if (!group) return [];
 		return (
 			this.statements.list_group_members.all(
@@ -481,8 +505,9 @@ export class TeamDatabase {
 
 	send_to_group(
 		input: Omit<CoordinationMessageInput, 'to_session_ids' | 'scope'>,
+		options: { cwd?: string } = {},
 	): CoordinationMessage {
-		const group = this.get_group(input.target);
+		const group = this.get_group(input.target, options);
 		if (!group) throw new Error(`Unknown group: ${input.target}`);
 		const members = this.list_group_members(group.group_id).filter(
 			(member) => member.status === 'active',
@@ -555,6 +580,58 @@ export class TeamDatabase {
 			session_id,
 			message_ids,
 		);
+	}
+
+	prune_historical_data(
+		options: CoordinationCleanupOptions = {},
+	): CoordinationCleanupResult {
+		const retention_ms =
+			options.retention_ms ?? DEFAULT_COORDINATION_RETENTION_MS;
+		if (!Number.isFinite(retention_ms) || retention_ms < 0)
+			throw new Error('Coordination retention must be non-negative');
+		const reference_time = options.reference_time ?? new Date();
+		if (Number.isNaN(reference_time.getTime()))
+			throw new Error(
+				'Coordination cleanup reference time is invalid',
+			);
+		const reference = reference_time.toISOString();
+		const cutoff = new Date(
+			reference_time.getTime() - retention_ms,
+		).toISOString();
+		const changes = (result: { changes: number | bigint }): number =>
+			Number(result.changes);
+		let cleanup_result: CoordinationCleanupResult | undefined;
+		this.transaction(() => {
+			const receipt_row = this.statements.count_prunable_receipts.get(
+				reference,
+				cutoff,
+			) as { count: number | bigint };
+			const events = changes(
+				this.statements.prune_events.run(cutoff),
+			);
+			const messages = changes(
+				this.statements.prune_messages.run(reference, cutoff),
+			);
+			const artifacts = changes(
+				this.statements.prune_artifacts.run(cutoff),
+			);
+			const groups = changes(
+				this.statements.prune_groups.run(cutoff, cutoff),
+			);
+			const sessions = changes(
+				this.statements.prune_sessions.run(cutoff),
+			);
+			cleanup_result = {
+				cutoff,
+				artifacts,
+				events,
+				groups,
+				messages,
+				receipts: Number(receipt_row.count),
+				sessions,
+			};
+		});
+		return cleanup_result!;
 	}
 
 	insert_event(input: {

--- a/packages/pi-team-mode/src/db/index.ts
+++ b/packages/pi-team-mode/src/db/index.ts
@@ -8,7 +8,7 @@ import { dirname } from 'node:path';
 
 import type { DatabaseSync, StatementSync } from 'node:sqlite';
 
-import { DEFAULT_COORDINATION_RETENTION_MS } from '../retention.js';
+import { DEFAULT_MANUAL_COORDINATION_RETENTION_MS } from '../retention.js';
 import {
 	find_stale_sessions,
 	type ProcessAliveCheck,
@@ -586,7 +586,8 @@ export class TeamDatabase {
 		options: CoordinationCleanupOptions = {},
 	): CoordinationCleanupResult {
 		const retention_ms =
-			options.retention_ms ?? DEFAULT_COORDINATION_RETENTION_MS;
+			options.retention_ms ??
+			DEFAULT_MANUAL_COORDINATION_RETENTION_MS;
 		if (!Number.isFinite(retention_ms) || retention_ms < 0)
 			throw new Error('Coordination retention must be non-negative');
 		const reference_time = options.reference_time ?? new Date();

--- a/packages/pi-team-mode/src/db/statements.ts
+++ b/packages/pi-team-mode/src/db/statements.ts
@@ -77,8 +77,11 @@ export function prepare_statements(
 				VALUES (?, ?, ?, ?, ?, ?, ?)
 			`),
 		get_group: db.prepare('SELECT * FROM groups WHERE group_id = ?'),
-		find_group_by_name: db.prepare(
-			'SELECT * FROM groups WHERE name = ? ORDER BY updated_at DESC LIMIT 1',
+		find_groups_by_name: db.prepare(
+			'SELECT * FROM groups WHERE name = ? ORDER BY group_id ASC',
+		),
+		find_groups_by_name_cwd: db.prepare(
+			'SELECT * FROM groups WHERE name = ? AND cwd = ? ORDER BY group_id ASC',
 		),
 		list_groups: db.prepare(
 			'SELECT * FROM groups ORDER BY updated_at DESC',
@@ -137,6 +140,93 @@ export function prepare_statements(
 		insert_event: db.prepare(`
 				INSERT INTO events (event_id, type, session_id, group_id, message_id, created_at, data_json)
 				VALUES (?, ?, ?, ?, ?, ?, ?)
+			`),
+		count_prunable_receipts: db.prepare(`
+				SELECT COUNT(*) AS count
+				FROM message_receipts
+				WHERE message_id IN (
+					SELECT messages.message_id
+					FROM messages
+					WHERE (expires_at IS NOT NULL AND expires_at <= ? OR created_at < ?)
+						AND NOT EXISTS (
+							SELECT 1 FROM message_receipts pending
+							WHERE pending.message_id = messages.message_id
+								AND pending.acknowledged_at IS NULL
+						)
+				)
+			`),
+		prune_events: db.prepare(
+			'DELETE FROM events WHERE created_at < ?',
+		),
+		prune_messages: db.prepare(`
+				DELETE FROM messages
+				WHERE (expires_at IS NOT NULL AND expires_at <= ? OR created_at < ?)
+					AND NOT EXISTS (
+						SELECT 1 FROM message_receipts
+						WHERE message_receipts.message_id = messages.message_id
+							AND message_receipts.acknowledged_at IS NULL
+					)
+			`),
+		prune_artifacts: db.prepare(`
+				DELETE FROM coordination_artifacts
+				WHERE updated_at < ?
+					AND NOT EXISTS (
+						SELECT 1
+						FROM messages
+						JOIN message_receipts ON message_receipts.message_id = messages.message_id
+						WHERE instr(messages.body, coordination_artifacts.artifact_id) > 0
+							AND message_receipts.acknowledged_at IS NULL
+					)
+			`),
+		prune_groups: db.prepare(`
+				DELETE FROM groups
+				WHERE updated_at < ?
+					AND NOT EXISTS (
+						SELECT 1
+						FROM group_members
+						JOIN sessions ON sessions.session_id = group_members.session_id
+						WHERE group_members.group_id = groups.group_id
+							AND group_members.status = 'active'
+							AND (
+								sessions.status != 'offline'
+								OR COALESCE(sessions.offline_at, sessions.last_seen_at) >= ?
+							)
+					)
+					AND NOT EXISTS (
+						SELECT 1
+						FROM messages
+						WHERE messages.scope = 'group'
+							AND messages.target = groups.group_id
+					)
+			`),
+		prune_sessions: db.prepare(`
+				DELETE FROM sessions
+				WHERE status = 'offline'
+					AND COALESCE(offline_at, last_seen_at) < ?
+					AND NOT EXISTS (
+						SELECT 1 FROM messages
+						WHERE messages.from_session_id = sessions.session_id
+					)
+					AND NOT EXISTS (
+						SELECT 1 FROM message_receipts
+						WHERE message_receipts.to_session_id = sessions.session_id
+					)
+					AND NOT EXISTS (
+						SELECT 1 FROM coordination_artifacts
+						WHERE coordination_artifacts.owner_session_id = sessions.session_id
+					)
+					AND NOT EXISTS (
+						SELECT 1 FROM group_members
+						WHERE group_members.session_id = sessions.session_id
+					)
+					AND NOT EXISTS (
+						SELECT 1 FROM session_runtimes
+						WHERE session_runtimes.session_id = sessions.session_id
+					)
+					AND NOT EXISTS (
+						SELECT 1 FROM runtime_events
+						WHERE runtime_events.session_id = sessions.session_id
+					)
 			`),
 	};
 }

--- a/packages/pi-team-mode/src/db/types.ts
+++ b/packages/pi-team-mode/src/db/types.ts
@@ -145,6 +145,21 @@ export interface CoordinationMessageInput {
 	metadata?: Record<string, unknown>;
 }
 
+export interface CoordinationCleanupOptions {
+	retention_ms?: number;
+	reference_time?: Date;
+}
+
+export interface CoordinationCleanupResult {
+	cutoff: string;
+	artifacts: number;
+	events: number;
+	groups: number;
+	messages: number;
+	receipts: number;
+	sessions: number;
+}
+
 export interface CoordinationMessage {
 	message_id: string;
 	from_session_id: string;
@@ -268,7 +283,8 @@ export interface TeamDatabaseStatements {
 	search_artifacts: StatementSync;
 	insert_group: StatementSync;
 	get_group: StatementSync;
-	find_group_by_name: StatementSync;
+	find_groups_by_name: StatementSync;
+	find_groups_by_name_cwd: StatementSync;
 	list_groups: StatementSync;
 	upsert_group_member: StatementSync;
 	list_group_members: StatementSync;
@@ -280,4 +296,10 @@ export interface TeamDatabaseStatements {
 	mark_messages_read: StatementSync;
 	mark_messages_acknowledged: StatementSync;
 	insert_event: StatementSync;
+	count_prunable_receipts: StatementSync;
+	prune_events: StatementSync;
+	prune_messages: StatementSync;
+	prune_artifacts: StatementSync;
+	prune_groups: StatementSync;
+	prune_sessions: StatementSync;
 }

--- a/packages/pi-team-mode/src/index.ts
+++ b/packages/pi-team-mode/src/index.ts
@@ -19,6 +19,7 @@ import {
 import { format_coordination_identity } from './coordination-formatting.js';
 import { CoordinationPoller } from './coordination-poller.js';
 import { TeamDatabase } from './db/index.js';
+import { get_coordination_retention_ms } from './retention.js';
 import { register_session_name_sync } from './session-name-sync.js';
 import {
 	detect_standby_registration,
@@ -156,6 +157,10 @@ export default async function team_mode(pi: ExtensionAPI) {
 				.map((tag) => tag.trim())
 				.filter(Boolean),
 		});
+		coordination_db.mark_stale_sessions_offline();
+		const retention_ms = get_coordination_retention_ms();
+		if (retention_ms !== undefined)
+			coordination_db.prune_historical_data({ retention_ms });
 		void ensure_coordination_broker();
 		coordination_broker.start();
 		coordination_poller.start(pi);

--- a/packages/pi-team-mode/src/index.ts
+++ b/packages/pi-team-mode/src/index.ts
@@ -19,7 +19,7 @@ import {
 import { format_coordination_identity } from './coordination-formatting.js';
 import { CoordinationPoller } from './coordination-poller.js';
 import { TeamDatabase } from './db/index.js';
-import { get_coordination_retention_ms } from './retention.js';
+import { get_startup_coordination_retention_ms } from './retention.js';
 import { register_session_name_sync } from './session-name-sync.js';
 import {
 	detect_standby_registration,
@@ -158,7 +158,7 @@ export default async function team_mode(pi: ExtensionAPI) {
 				.filter(Boolean),
 		});
 		coordination_db.mark_stale_sessions_offline();
-		const retention_ms = get_coordination_retention_ms();
+		const retention_ms = get_startup_coordination_retention_ms();
 		if (retention_ms !== undefined)
 			coordination_db.prune_historical_data({ retention_ms });
 		void ensure_coordination_broker();

--- a/packages/pi-team-mode/src/retention.test.ts
+++ b/packages/pi-team-mode/src/retention.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	DEFAULT_COORDINATION_RETENTION_MS,
+	get_coordination_retention_ms,
+	TEAM_RETENTION_DAYS_ENV,
+} from './retention.js';
+
+const original_retention = process.env[TEAM_RETENTION_DAYS_ENV];
+
+afterEach(() => {
+	if (original_retention === undefined)
+		delete process.env[TEAM_RETENTION_DAYS_ENV];
+	else process.env[TEAM_RETENTION_DAYS_ENV] = original_retention;
+});
+
+describe('coordination retention', () => {
+	it('defaults to thirty days and accepts a positive day override', () => {
+		delete process.env[TEAM_RETENTION_DAYS_ENV];
+		expect(get_coordination_retention_ms()).toBe(
+			DEFAULT_COORDINATION_RETENTION_MS,
+		);
+
+		process.env[TEAM_RETENTION_DAYS_ENV] = '7.5';
+		expect(get_coordination_retention_ms()).toBe(
+			7.5 * 24 * 60 * 60 * 1000,
+		);
+	});
+
+	it('can disable startup cleanup without accepting unsafe values', () => {
+		process.env[TEAM_RETENTION_DAYS_ENV] = 'off';
+		expect(get_coordination_retention_ms()).toBeUndefined();
+
+		process.env[TEAM_RETENTION_DAYS_ENV] = '-1';
+		expect(get_coordination_retention_ms()).toBe(
+			DEFAULT_COORDINATION_RETENTION_MS,
+		);
+	});
+});

--- a/packages/pi-team-mode/src/retention.test.ts
+++ b/packages/pi-team-mode/src/retention.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
-	DEFAULT_COORDINATION_RETENTION_MS,
-	get_coordination_retention_ms,
+	get_startup_coordination_retention_ms,
 	TEAM_RETENTION_DAYS_ENV,
 } from './retention.js';
 
@@ -13,26 +12,38 @@ afterEach(() => {
 	else process.env[TEAM_RETENTION_DAYS_ENV] = original_retention;
 });
 
-describe('coordination retention', () => {
-	it('defaults to thirty days and accepts a positive day override', () => {
+describe('startup coordination retention', () => {
+	it('does not prune by default', () => {
 		delete process.env[TEAM_RETENTION_DAYS_ENV];
-		expect(get_coordination_retention_ms()).toBe(
-			DEFAULT_COORDINATION_RETENTION_MS,
-		);
-
-		process.env[TEAM_RETENTION_DAYS_ENV] = '7.5';
-		expect(get_coordination_retention_ms()).toBe(
-			7.5 * 24 * 60 * 60 * 1000,
-		);
+		expect(get_startup_coordination_retention_ms()).toBeUndefined();
 	});
 
-	it('can disable startup cleanup without accepting unsafe values', () => {
-		process.env[TEAM_RETENTION_DAYS_ENV] = 'off';
-		expect(get_coordination_retention_ms()).toBeUndefined();
+	it.each([
+		'',
+		'   ',
+		'0',
+		'0.0',
+		'-0',
+		'off',
+		'OFF',
+		'false',
+		'disabled',
+		'-1',
+		'invalid',
+		'Infinity',
+		'1e308',
+	])(
+		'does not prune for disabled or unsafe setting %j',
+		(configured) => {
+			process.env[TEAM_RETENTION_DAYS_ENV] = configured;
+			expect(get_startup_coordination_retention_ms()).toBeUndefined();
+		},
+	);
 
-		process.env[TEAM_RETENTION_DAYS_ENV] = '-1';
-		expect(get_coordination_retention_ms()).toBe(
-			DEFAULT_COORDINATION_RETENTION_MS,
+	it('enables startup pruning for a valid positive day count', () => {
+		process.env[TEAM_RETENTION_DAYS_ENV] = '7.5';
+		expect(get_startup_coordination_retention_ms()).toBe(
+			7.5 * 24 * 60 * 60 * 1000,
 		);
 	});
 });

--- a/packages/pi-team-mode/src/retention.ts
+++ b/packages/pi-team-mode/src/retention.ts
@@ -1,10 +1,12 @@
 export const TEAM_RETENTION_DAYS_ENV = 'MY_PI_TEAM_RETENTION_DAYS';
-export const DEFAULT_COORDINATION_RETENTION_MS =
+export const DEFAULT_MANUAL_COORDINATION_RETENTION_MS =
 	30 * 24 * 60 * 60 * 1000;
 
-export function get_coordination_retention_ms(): number | undefined {
+export function get_startup_coordination_retention_ms():
+	| number
+	| undefined {
 	const configured = process.env[TEAM_RETENTION_DAYS_ENV]?.trim();
-	if (!configured) return DEFAULT_COORDINATION_RETENTION_MS;
+	if (!configured) return undefined;
 	if (
 		['0', 'off', 'false', 'disabled'].includes(
 			configured.toLowerCase(),
@@ -12,7 +14,7 @@ export function get_coordination_retention_ms(): number | undefined {
 	)
 		return undefined;
 	const days = Number(configured);
-	if (!Number.isFinite(days) || days <= 0)
-		return DEFAULT_COORDINATION_RETENTION_MS;
-	return days * 24 * 60 * 60 * 1000;
+	if (!Number.isFinite(days) || days <= 0) return undefined;
+	const retention_ms = days * 24 * 60 * 60 * 1000;
+	return Number.isFinite(retention_ms) ? retention_ms : undefined;
 }

--- a/packages/pi-team-mode/src/retention.ts
+++ b/packages/pi-team-mode/src/retention.ts
@@ -1,0 +1,18 @@
+export const TEAM_RETENTION_DAYS_ENV = 'MY_PI_TEAM_RETENTION_DAYS';
+export const DEFAULT_COORDINATION_RETENTION_MS =
+	30 * 24 * 60 * 60 * 1000;
+
+export function get_coordination_retention_ms(): number | undefined {
+	const configured = process.env[TEAM_RETENTION_DAYS_ENV]?.trim();
+	if (!configured) return DEFAULT_COORDINATION_RETENTION_MS;
+	if (
+		['0', 'off', 'false', 'disabled'].includes(
+			configured.toLowerCase(),
+		)
+	)
+		return undefined;
+	const days = Number(configured);
+	if (!Number.isFinite(days) || days <= 0)
+		return DEFAULT_COORDINATION_RETENTION_MS;
+	return days * 24 * 60 * 60 * 1000;
+}

--- a/packages/pi-team-mode/src/tools/coordination-actions.test.ts
+++ b/packages/pi-team-mode/src/tools/coordination-actions.test.ts
@@ -66,6 +66,90 @@ describe('coordination actions', () => {
 		}
 	});
 
+	it('lists directly copyable targets that remain unambiguous after compact-prefix collisions', async () => {
+		const db = await tmp_db();
+		try {
+			const first_id = '019f0f71-967e-7aed-853c-94ac29fbe7b6';
+			const second_id = '019f0f71-967f-7aed-853c-94ac29fbe7b6';
+			const hidden_collision = '019f0f71-967eX7aed-853c-94ac29fbe7b6';
+			db.register_session({ session_id: first_id, cwd: '/repo' });
+			db.register_session({ session_id: second_id, cwd: '/repo' });
+			db.register_session({
+				session_id: hidden_collision,
+				cwd: '/repo',
+			});
+			db.mark_session_status(hidden_collision, 'offline');
+
+			const result = await execute_coordination_action(
+				{ action: 'session_list' },
+				{
+					ctx: { cwd: '/repo' },
+					coordination_db: db,
+					notify_coordination_messages: async () => undefined,
+					require_session_id: () => first_id,
+				},
+			);
+			const targets = result.content[0]!.text.split('\n').map(
+				(line) => line.slice(2).split(' ')[0]!,
+			);
+
+			expect(targets).toHaveLength(2);
+			expect(targets[0]).not.toBe(targets[1]);
+			expect(result.content[0]!.text).toContain(
+				first_id.slice(0, 14),
+			);
+			expect(result.content[0]!.text).not.toContain('…');
+			for (const target of targets)
+				expect(db.resolve_session_targets(target)).toHaveLength(1);
+		} finally {
+			db.close();
+		}
+	});
+
+	it('scopes group names to the caller cwd while exact ids remain global', async () => {
+		const db = await tmp_db();
+		try {
+			db.register_session({ session_id: 'lead-a', cwd: '/repo-a' });
+			db.register_session({ session_id: 'lead-b', cwd: '/repo-b' });
+			const group_a = db.create_group({
+				name: 'review',
+				cwd: '/repo-a',
+				created_by_session_id: 'lead-a',
+			});
+			const group_b = db.create_group({
+				name: 'review',
+				cwd: '/repo-b',
+				created_by_session_id: 'lead-b',
+			});
+			const context = {
+				ctx: { cwd: '/repo-a' },
+				coordination_db: db,
+				notify_coordination_messages: async () => undefined,
+				require_session_id: () => 'lead-a',
+			};
+
+			const local = await execute_coordination_action(
+				{ action: 'group_join', name: 'review' },
+				context,
+			);
+			const exact = await execute_coordination_action(
+				{ action: 'group_join', team_id: group_b.group_id },
+				context,
+			);
+
+			expect(local.details.group?.group_id).toBe(group_a.group_id);
+			expect(exact.details.group?.group_id).toBe(group_b.group_id);
+			await expect(
+				execute_coordination_action(
+					{ action: 'group_join', name: 'review' },
+					{ ...context, ctx: { cwd: '/repo-c' } },
+				),
+			).rejects.toThrow('Unknown coordination group');
+		} finally {
+			db.close();
+		}
+	});
+
 	it('rejects unregistered and foreign send-side identities', async () => {
 		const db = await tmp_db();
 		try {

--- a/packages/pi-team-mode/src/tools/coordination-actions.ts
+++ b/packages/pi-team-mode/src/tools/coordination-actions.ts
@@ -139,15 +139,24 @@ export async function execute_coordination_action(
 		case 'session_list': {
 			coordination_db.mark_stale_sessions_offline();
 			const full = params.mode === 'full';
-			const sessions = coordination_db.list_sessions({
-				include_offline: full || params.include_read,
+			const all_sessions = coordination_db.list_sessions({
+				include_offline: true,
 			});
+			const sessions =
+				full || params.include_read
+					? all_sessions
+					: all_sessions.filter(
+							(session) => session.status !== 'offline',
+						);
 			return {
 				content: [
 					{
 						type: 'text' as const,
 						text: format_sessions(sessions, {
 							full_ids: full,
+							target_ids: all_sessions.map(
+								(session) => session.session_id,
+							),
 						}),
 					},
 				],
@@ -432,6 +441,7 @@ export async function execute_coordination_action(
 		case 'group_join': {
 			const group = coordination_db.get_group(
 				require_arg(params.team_id ?? params.name, 'group'),
+				{ cwd: ctx.cwd },
 			);
 			if (!group) throw new Error('Unknown coordination group');
 			const member = coordination_db.add_group_member({
@@ -454,6 +464,7 @@ export async function execute_coordination_action(
 			coordination_db.mark_stale_sessions_offline();
 			const group = coordination_db.get_group(
 				require_arg(params.team_id ?? params.name, 'group'),
+				{ cwd: ctx.cwd },
 			);
 			if (!group) throw new Error('Unknown coordination group');
 			const from_session_id = require_session_id();
@@ -503,19 +514,22 @@ export async function execute_coordination_action(
 			);
 			const from_session_id = require_session_id();
 			const members = coordination_db
-				.list_group_members(group_target)
+				.list_group_members(group_target, { cwd: ctx.cwd })
 				.filter((member) => member.session_id !== from_session_id);
 			const recipients = members.map((member) => member.session_id);
 			const body = require_arg(params.message, 'message');
-			const message = coordination_db.send_to_group({
-				from_session_id,
-				target: group_target,
-				body,
-				urgent: params.urgent,
-				reply_to: params.reply_to,
-				ttl_ms: params.ttl_ms,
-				requires_ack: params.requires_ack,
-			});
+			const message = coordination_db.send_to_group(
+				{
+					from_session_id,
+					target: group_target,
+					body,
+					urgent: params.urgent,
+					reply_to: params.reply_to,
+					ttl_ms: params.ttl_ms,
+					requires_ack: params.requires_ack,
+				},
+				{ cwd: ctx.cwd },
+			);
 			await notify_coordination_messages(
 				recipients,
 				message.message_id,


### PR DESCRIPTION
## Summary

- resolve group names only within the caller cwd while preserving exact group-id targeting
- expose copyable, collision-safe compact session targets, including collisions with hidden offline history
- retain safe historical-data pruning while making startup cleanup strictly opt-in
- disable startup pruning for unset, blank, zero, disabling, invalid, negative, or overflowing retention settings
- preserve active/recent peer state, unacknowledged messages, referenced artifacts, and dormant runtime compatibility
- document Team Mode messages and artifacts as intentional coordination records rather than derived data
- leave merged #292 session-name synchronization unchanged

## Retention behavior

`MY_PI_TEAM_RETENTION_DAYS` enables startup pruning only when it contains a valid positive day count. Team Mode performs no startup cleanup by default. The intentionally invoked `prune_historical_data()` database API retains its documented 30-day default and accepts an explicit `retention_ms` override.

## Validation

- `pnpm --filter @spences10/pi-team-mode run check:self`
- `pnpm --filter @spences10/pi-team-mode run test:self` (18 files, 89 tests)
- `pnpm run check`
- `pnpm run test`
- `git diff --check`
- Changeset verified as patch with exactly 15 whitespace-separated summary words
- LSP diagnostics: the built-in service could not initialize against the repository TypeScript 7 install; a fresh direct pi-lsp client using TypeScript 5.9 reported zero diagnostics across all five changed TypeScript files

Closes #313